### PR TITLE
Automatise l'activation des catégories POS selon le jour

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Ce dépôt contient des scripts d'automatisation autour d'Odoo. On y génère de
 - **generate_post/** : scripts de génération de posts (Facebook, LinkedIn, X) basés sur ChatGPT. Les prompts sont stockés dans `prompts/`.
 - **schedule_post_in_odoo/** : script pour planifier une publication dans Odoo (exemple pour Facebook).
 - **pos_product_interaction/** : exemples de manipulation de produits du point de vente (duplication).
+- **pos_category_management/** : activation ou désactivation automatique des catégories du point de vente selon le jour.
 - **tests/** : quelques tests unitaires couvrant la configuration et l'intégration.
 
 ## Dépendances
@@ -48,6 +49,10 @@ Ces variables permettent de se connecter à Odoo et à l'API OpenAI.
 - Planifier un post dans Odoo :
   ```bash
   python schedule_post_in_odoo/schedule_facebook_post.py
+  ```
+- Mettre à jour automatiquement les catégories POS selon le jour :
+  ```bash
+  python pos_category_management/manage_pos_categories.py
   ```
 
 ## Exécution des tests

--- a/pos_category_management/manage_pos_categories.py
+++ b/pos_category_management/manage_pos_categories.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from typing import Iterable, Tuple
+
+from config.odoo_connect import get_odoo_connection
+from config.log_config import setup_logger
+
+logger = setup_logger()
+
+FRIDAY_CATEGORIES = ["BUVETTE", "EPICERIE"]
+SUNDAY_CATEGORY = "FOURNIL"
+
+
+def _search_category(models, db, uid, password, name):
+    return models.execute_kw(db, uid, password, 'pos.category', 'search', [[('name', '=', name)]])
+
+
+def _ensure_category_active(models, db, uid, password, name):
+    ids = _search_category(models, db, uid, password, name)
+    if ids:
+        models.execute_kw(db, uid, password, 'pos.category', 'write', [ids, {'active': True}])
+        return ids[0]
+    return models.execute_kw(db, uid, password, 'pos.category', 'create', [{'name': name}])
+
+
+def _deactivate_category(models, db, uid, password, name):
+    ids = _search_category(models, db, uid, password, name)
+    if ids:
+        models.execute_kw(db, uid, password, 'pos.category', 'write', [ids, {'active': False}])
+
+
+def compute_category_actions(current_dt: datetime) -> Tuple[Iterable[str], Iterable[str]]:
+    """Return categories to activate and deactivate for given datetime."""
+    weekday = current_dt.weekday()
+    hour = current_dt.hour
+
+    if weekday == 4 and hour >= 18:  # Friday evening
+        return FRIDAY_CATEGORIES, [SUNDAY_CATEGORY]
+    if weekday == 6:  # Sunday
+        return [SUNDAY_CATEGORY], FRIDAY_CATEGORIES
+    return [], FRIDAY_CATEGORIES + [SUNDAY_CATEGORY]
+
+
+def update_pos_categories(current_dt: datetime | None = None):
+    """Update POS categories according to the current day and time."""
+    if current_dt is None:
+        current_dt = datetime.now()
+
+    to_activate, to_deactivate = compute_category_actions(current_dt)
+
+    db, uid, password, models = get_odoo_connection()
+
+    for name in to_activate:
+        try:
+            _ensure_category_active(models, db, uid, password, name)
+            logger.info("Catégorie POS activée : %s", name)
+        except Exception as err:
+            logger.error("Erreur lors de l'activation de la catégorie %s : %s", name, err)
+
+    for name in to_deactivate:
+        try:
+            _deactivate_category(models, db, uid, password, name)
+            logger.info("Catégorie POS désactivée : %s", name)
+        except Exception as err:
+            logger.error("Erreur lors de la désactivation de la catégorie %s : %s", name, err)
+
+
+if __name__ == "__main__":
+    update_pos_categories()

--- a/tests/test_manage_pos_categories.py
+++ b/tests/test_manage_pos_categories.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+import unittest
+
+from pos_category_management.manage_pos_categories import compute_category_actions
+
+
+class TestComputeCategoryActions(unittest.TestCase):
+    def test_friday_evening(self):
+        dt = datetime(2024, 9, 6, 19, 0)  # Friday 19:00
+        add, remove = compute_category_actions(dt)
+        self.assertEqual(set(add), {"BUVETTE", "EPICERIE"})
+        self.assertEqual(set(remove), {"FOURNIL"})
+
+    def test_sunday(self):
+        dt = datetime(2024, 9, 8, 10, 0)  # Sunday morning
+        add, remove = compute_category_actions(dt)
+        self.assertEqual(set(add), {"FOURNIL"})
+        self.assertEqual(set(remove), {"BUVETTE", "EPICERIE"})
+
+    def test_other_day(self):
+        dt = datetime(2024, 9, 4, 12, 0)  # Wednesday
+        add, remove = compute_category_actions(dt)
+        self.assertEqual(set(add), set())
+        self.assertEqual(set(remove), {"BUVETTE", "EPICERIE", "FOURNIL"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add module to activate or disable POS categories based on the current weekday
- document new automation and its usage
- test category selection logic for Friday evenings, Sundays and other days

## Testing
- `pytest` *(fails: Name or service not known, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a242e1f100832580cf3b49c952ef68