### PR TITLE
Document POS category IDs and test compute_category_actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,30 @@ Ces variables permettent de se connecter à Odoo et à l'API OpenAI.
   ```
   Ce script active BUVETTE, EPICERIE et BUREAU le vendredi à partir de 6h, puis BUVETTE, EPICERIE, BUREAU et FOURNIL le dimanche à partir de 6h. Les autres jours, ces catégories sont désactivées.
 
+  Chaque catégorie POS possède aussi un **ID Odoo** utile pour les tests ou les vérifications manuelles. Voici les correspondances actuelles :
+
+  - BUVETTE : `79`
+  - EPICERIE : `72`
+  - BUREAU : `53`
+  - FOURNIL : `58`
+
+  Pour convertir les noms renvoyés par `compute_category_actions` en IDs :
+
+  ```python
+  from datetime import datetime
+  from pos_category_management.manage_pos_categories import compute_category_actions
+
+  CATEGORY_IDS = {"BUVETTE": 79, "EPICERIE": 72, "BUREAU": 53, "FOURNIL": 58}
+
+  add, remove = compute_category_actions(datetime(2024, 9, 6, 7))  # Vendredi 07h
+  add_ids = [CATEGORY_IDS[name] for name in add]
+  # add_ids == [79, 72, 53]
+
+  add, remove = compute_category_actions(datetime(2024, 9, 8, 10))  # Dimanche 10h
+  add_ids = [CATEGORY_IDS[name] for name in add]
+  # add_ids == [79, 72, 53, 58]
+  ```
+
 ## Exécution des tests
 
 Les tests utilisent `unittest` et se lancent avec :

--- a/tests/test_manage_pos_categories.py
+++ b/tests/test_manage_pos_categories.py
@@ -4,24 +4,31 @@ import unittest
 from pos_category_management.manage_pos_categories import compute_category_actions
 
 
+CATEGORY_IDS = {"BUVETTE": 79, "EPICERIE": 72, "BUREAU": 53, "FOURNIL": 58}
+
+
+def ids(names):
+    return [CATEGORY_IDS[name] for name in names]
+
+
 class TestComputeCategoryActions(unittest.TestCase):
     def test_friday_morning(self):
         dt = datetime(2024, 9, 6, 7, 0)  # Friday 07:00
         add, remove = compute_category_actions(dt)
-        self.assertEqual(set(add), {"BUVETTE", "EPICERIE", "BUREAU"})
-        self.assertEqual(set(remove), {"FOURNIL"})
+        self.assertEqual(ids(add), [79, 72, 53])
+        self.assertEqual(ids(remove), [58])
 
     def test_sunday_morning(self):
         dt = datetime(2024, 9, 8, 10, 0)  # Sunday 10:00
         add, remove = compute_category_actions(dt)
-        self.assertEqual(set(add), {"BUVETTE", "FOURNIL", "EPICERIE", "BUREAU"})
-        self.assertEqual(set(remove), set())
+        self.assertEqual(ids(add), [79, 72, 53, 58])
+        self.assertEqual(ids(remove), [])
 
     def test_other_day(self):
         dt = datetime(2024, 9, 4, 12, 0)  # Wednesday
         add, remove = compute_category_actions(dt)
-        self.assertEqual(set(add), set())
-        self.assertEqual(set(remove), {"BUVETTE", "EPICERIE", "BUREAU", "FOURNIL"})
+        self.assertEqual(ids(add), [])
+        self.assertEqual(ids(remove), [79, 72, 53, 58])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- document POS category ID usage and mapping in README
- verify `compute_category_actions` against expected category ID lists

## Testing
- `python -m unittest tests/test_manage_pos_categories.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68a375d8b57083259d3519174ecac674