### PR TITLE
refactor POS category management to operate on IDs

### DIFF
--- a/pos_category_management/manage_pos_categories.py
+++ b/pos_category_management/manage_pos_categories.py
@@ -1,44 +1,84 @@
 from datetime import datetime
-from typing import Iterable, Tuple
 
 from config.odoo_connect import get_odoo_connection
 from config.log_config import setup_logger
 
 logger = setup_logger()
 
-FRIDAY_CATEGORIES = ["BUVETTE", "EPICERIE", "BUREAU"]
-SUNDAY_CATEGORY = "FOURNIL"
-SUNDAY_CATEGORIES = FRIDAY_CATEGORIES + [SUNDAY_CATEGORY]
+# Category identifiers used for automatic activation/deactivation.
+# These values come from the Odoo database and therefore are integers
+# rather than category names.
+FRIDAY_CATEGORY_IDS: tuple[int, ...] = (79, 72, 53)
+SUNDAY_CATEGORY_IDS: tuple[int, ...] = FRIDAY_CATEGORY_IDS + (58,)
 
 
-def _search_category(models, db, uid, password, name):
-    return models.execute_kw(db, uid, password, 'pos.category', 'search', [[('name', '=', name)]])
+def _ensure_category_active(models, db, uid, password, category_id):
+    """Ensure the given category is available in the POS."""
+    try:
+        models.execute_kw(
+            db,
+            uid,
+            password,
+            "pos.category",
+            "write",
+            [[category_id], {"available_in_pos": True}],
+        )
+    except Exception:
+        # Fallback for older versions where categories are controlled
+        # through the POS configuration record.
+        config_ids = models.execute_kw(
+            db, uid, password, "pos.config", "search", [[]], {"limit": 1}
+        )
+        if config_ids:
+            models.execute_kw(
+                db,
+                uid,
+                password,
+                "pos.config",
+                "write",
+                [[config_ids[0]], {"iface_available_categ_ids": [(4, category_id)]}],
+            )
 
 
-def _ensure_category_active(models, db, uid, password, name):
-    ids = _search_category(models, db, uid, password, name)
-    if ids:
-        models.execute_kw(db, uid, password, 'pos.category', 'write', [ids, {'active': True}])
-        return ids[0]
-    return models.execute_kw(db, uid, password, 'pos.category', 'create', [{'name': name}])
+def _deactivate_category(models, db, uid, password, category_id):
+    """Make the given category unavailable in the POS."""
+    try:
+        models.execute_kw(
+            db,
+            uid,
+            password,
+            "pos.category",
+            "write",
+            [[category_id], {"available_in_pos": False}],
+        )
+    except Exception:
+        config_ids = models.execute_kw(
+            db, uid, password, "pos.config", "search", [[]], {"limit": 1}
+        )
+        if config_ids:
+            models.execute_kw(
+                db,
+                uid,
+                password,
+                "pos.config",
+                "write",
+                [[config_ids[0]], {"iface_available_categ_ids": [(3, category_id)]}],
+            )
 
 
-def _deactivate_category(models, db, uid, password, name):
-    ids = _search_category(models, db, uid, password, name)
-    if ids:
-        models.execute_kw(db, uid, password, 'pos.category', 'write', [ids, {'active': False}])
-
-
-def compute_category_actions(current_dt: datetime) -> Tuple[Iterable[str], Iterable[str]]:
-    """Return categories to activate and deactivate for given datetime."""
+def compute_category_actions(
+    current_dt: datetime,
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Return category IDs to activate and deactivate for given datetime."""
     weekday = current_dt.weekday()
     hour = current_dt.hour
 
     if weekday == 4 and hour >= 6:  # Friday from 6 AM
-        return FRIDAY_CATEGORIES, [SUNDAY_CATEGORY]
+        # Activate Friday categories and deactivate the Sunday-only one.
+        return FRIDAY_CATEGORY_IDS, (58,)
     if weekday == 6 and hour >= 6:  # Sunday from 6 AM
-        return SUNDAY_CATEGORIES, []
-    return [], SUNDAY_CATEGORIES
+        return SUNDAY_CATEGORY_IDS, ()
+    return (), SUNDAY_CATEGORY_IDS
 
 
 def update_pos_categories(current_dt: datetime | None = None):
@@ -50,19 +90,27 @@ def update_pos_categories(current_dt: datetime | None = None):
 
     db, uid, password, models = get_odoo_connection()
 
-    for name in to_activate:
+    for category_id in to_activate:
         try:
-            _ensure_category_active(models, db, uid, password, name)
-            logger.info("Catégorie POS activée : %s", name)
+            _ensure_category_active(models, db, uid, password, category_id)
+            logger.info("Catégorie POS activée : %s", category_id)
         except Exception as err:
-            logger.error("Erreur lors de l'activation de la catégorie %s : %s", name, err)
+            logger.error(
+                "Erreur lors de l'activation de la catégorie %s : %s",
+                category_id,
+                err,
+            )
 
-    for name in to_deactivate:
+    for category_id in to_deactivate:
         try:
-            _deactivate_category(models, db, uid, password, name)
-            logger.info("Catégorie POS désactivée : %s", name)
+            _deactivate_category(models, db, uid, password, category_id)
+            logger.info("Catégorie POS désactivée : %s", category_id)
         except Exception as err:
-            logger.error("Erreur lors de la désactivation de la catégorie %s : %s", name, err)
+            logger.error(
+                "Erreur lors de la désactivation de la catégorie %s : %s",
+                category_id,
+                err,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_manage_pos_categories.py
+++ b/tests/test_manage_pos_categories.py
@@ -8,20 +8,26 @@ class TestComputeCategoryActions(unittest.TestCase):
     def test_friday_morning(self):
         dt = datetime(2024, 9, 6, 7, 0)  # Friday 07:00
         add, remove = compute_category_actions(dt)
-        self.assertEqual(set(add), {"BUVETTE", "EPICERIE", "BUREAU"})
-        self.assertEqual(set(remove), {"FOURNIL"})
+        self.assertIsInstance(add, tuple)
+        self.assertIsInstance(remove, tuple)
+        self.assertEqual(set(add), {79, 72, 53})
+        self.assertEqual(set(remove), {58})
 
     def test_sunday_morning(self):
         dt = datetime(2024, 9, 8, 10, 0)  # Sunday 10:00
         add, remove = compute_category_actions(dt)
-        self.assertEqual(set(add), {"BUVETTE", "FOURNIL", "EPICERIE", "BUREAU"})
+        self.assertIsInstance(add, tuple)
+        self.assertIsInstance(remove, tuple)
+        self.assertEqual(set(add), {79, 72, 53, 58})
         self.assertEqual(set(remove), set())
 
     def test_other_day(self):
         dt = datetime(2024, 9, 4, 12, 0)  # Wednesday
         add, remove = compute_category_actions(dt)
+        self.assertIsInstance(add, tuple)
+        self.assertIsInstance(remove, tuple)
         self.assertEqual(set(add), set())
-        self.assertEqual(set(remove), {"BUVETTE", "EPICERIE", "BUREAU", "FOURNIL"})
+        self.assertEqual(set(remove), {79, 72, 53, 58})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch POS category scheduling from names to hard-coded IDs
- ensure categories are toggled via `available_in_pos` or POS config fallback
- update compute_category_actions and associated tests to use integer IDs
- return immutable ID tuples and assert tuple results in tests

## Testing
- `pytest tests/test_manage_pos_categories.py -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68a375c34c688325b946585cf79fc39b