### PR TITLE
Add group data loader utility

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,1 @@
+from .group_data_loader import load_group_data

--- a/config/group_data_loader.py
+++ b/config/group_data_loader.py
@@ -1,0 +1,22 @@
+# config/group_data_loader.py
+
+import json
+import os
+from .log_config import setup_logger
+
+logger = setup_logger()
+
+def load_group_data(file_name="group_data.json"):
+    """
+    Charge les données de groupe depuis un fichier JSON.
+    """
+    try:
+        base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        file_path = os.path.join(base_dir, file_name)
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        logger.info(f"Données de groupe chargées depuis {file_path}.")
+        return data
+    except Exception as e:
+        logger.error(f"Erreur lors du chargement des données de groupe : {e}")
+        return {}

--- a/group_data.json
+++ b/group_data.json
@@ -1,0 +1,4 @@
+{
+  "mega_groupe_ariege": ["ID1", "ID2"],
+  "mega_groupe_vallees": ["ID3"]
+}

--- a/tests/test_group_data_loader.py
+++ b/tests/test_group_data_loader.py
@@ -1,0 +1,14 @@
+# tests/test_group_data_loader.py
+
+import unittest
+from config.group_data_loader import load_group_data
+
+class TestGroupDataLoader(unittest.TestCase):
+    def test_load_group_data(self):
+        data = load_group_data()
+        self.assertIn("mega_groupe_ariege", data)
+        self.assertEqual(data["mega_groupe_ariege"], ["ID1", "ID2"])
+        self.assertEqual(data["mega_groupe_vallees"], ["ID3"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add JSON mapping of groups and utility function to load it
- expose loader via config package and cover with a unit test

## Testing
- `pytest -q` *(fails: unsupported XML-RPC protocol; missing Odoo environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68a448ff36f883258d9b028214575d6d