### PR TITLE
Add utilities to generate post versions and illustrations

### DIFF
--- a/config/openai_utils.py
+++ b/config/openai_utils.py
@@ -50,3 +50,46 @@ def chat_gpt(prompt, model="gpt-4.1", system_prompt=prompt_system):
     except Exception as e:
         logger.error(f"Erreur lors de l'appel OpenAI : {e}")
         return None
+
+
+def generate_post_versions(text, model="gpt-4o-mini"):
+    """Génère trois versions alternatives d'un texte donné.
+
+    Args:
+        text: Le texte source à transformer.
+        model: Le modèle OpenAI à utiliser.
+
+    Returns:
+        Une liste contenant jusqu'à trois versions du texte.
+    """
+    prompt = (
+        "Propose trois versions différentes du texte suivant. "
+        "Sépare chaque version par une nouvelle ligne :\n"
+        f"{text}"
+    )
+    response = chat_gpt(prompt, model=model)
+    if not response:
+        return []
+    versions = [line.strip(" -\t") for line in response.splitlines() if line.strip()]
+    return versions[:3]
+
+
+def generate_illustrations(prompt_text):
+    """Génère trois illustrations à partir d'un prompt texte."""
+    try:
+        logger.info(f"Génération d'illustrations : {prompt_text}")
+        response = openai.images.generate(
+            model="dall-e-3",
+            prompt=prompt_text,
+            n=3,
+            size="1024x1024"
+        )
+        urls = []
+        for data in response.data:
+            url = data.get("url") if isinstance(data, dict) else getattr(data, "url", None)
+            if url:
+                urls.append(url)
+        return urls
+    except Exception as e:
+        logger.error(f"Erreur lors de la génération d'images : {e}")
+        return []

--- a/tests/test_generate_content.py
+++ b/tests/test_generate_content.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from config.openai_utils import generate_post_versions, generate_illustrations
+
+
+class TestGenerateContent(unittest.TestCase):
+    @patch('config.openai_utils.chat_gpt')
+    def test_generate_post_versions(self, mock_chat):
+        mock_chat.return_value = "Version 1\nVersion 2\nVersion 3"
+        result = generate_post_versions("Mon texte")
+        self.assertEqual(result, ["Version 1", "Version 2", "Version 3"])
+
+    @patch('config.openai_utils.openai.images.generate')
+    def test_generate_illustrations(self, mock_image):
+        mock_resp = MagicMock()
+        mock_resp.data = [MagicMock(url=f"url{i}") for i in range(1, 4)]
+        mock_image.return_value = mock_resp
+        result = generate_illustrations("Une maison")
+        self.assertEqual(result, ["url1", "url2", "url3"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `generate_post_versions` to create 3 text variants via OpenAI ChatGPT
- add `generate_illustrations` for generating DALL·E 3 images and returning URLs
- cover new functions with unit tests using mocks

## Testing
- `pytest tests/test_generate_content.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a448f616b083258cf2dc33bf41d5f6