### PR TITLE
Add Facebook page posting utilities

### DIFF
--- a/facebook_post/__init__.py
+++ b/facebook_post/__init__.py
@@ -1,0 +1,3 @@
+from .facebook_api import post_to_facebook_page, cross_post_to_groups
+
+__all__ = ["post_to_facebook_page", "cross_post_to_groups"]

--- a/facebook_post/facebook_api.py
+++ b/facebook_post/facebook_api.py
@@ -1,0 +1,64 @@
+import os
+import json
+from urllib import request, parse
+from dotenv import load_dotenv
+from config.log_config import setup_logger
+
+load_dotenv(override=True)
+
+logger = setup_logger()
+GRAPH_API_URL = "https://graph.facebook.com"
+
+PAGE_ID = os.getenv("FB_PAGE_ID")
+ACCESS_TOKEN = os.getenv("FB_PAGE_ACCESS_TOKEN")
+
+def _post(url, data):
+    encoded = parse.urlencode(data).encode()
+    req = request.Request(url, data=encoded, method="POST")
+    with request.urlopen(req) as resp:
+        body = resp.read().decode()
+        return json.loads(body)
+
+def _upload_image_to_page(image_url):
+    """Upload an image to the Facebook page without publishing it."""
+    url = f"{GRAPH_API_URL}/{PAGE_ID}/photos"
+    data = {
+        "url": image_url,
+        "published": "false",
+        "access_token": ACCESS_TOKEN,
+    }
+    response = _post(url, data)
+    media_id = response.get("id")
+    logger.info(f"Image uploaded with media_fbid {media_id}")
+    return media_id
+
+def post_to_facebook_page(message, image_url=None):
+    """Post a message to the Facebook page and return its post_id."""
+    url = f"{GRAPH_API_URL}/{PAGE_ID}/feed"
+    data = {
+        "message": message,
+        "access_token": ACCESS_TOKEN,
+    }
+    if image_url:
+        media_id = _upload_image_to_page(image_url)
+        data["attached_media[0]"] = json.dumps({"media_fbid": media_id})
+    response = _post(url, data)
+    post_id = response.get("id")
+    logger.info(f"Post published with id {post_id}")
+    return post_id
+
+def cross_post_to_groups(post_id, group_ids):
+    """Cross-post an existing page post to multiple Facebook groups."""
+    results = []
+    link = f"https://www.facebook.com/{post_id}"
+    for gid in group_ids:
+        url = f"{GRAPH_API_URL}/{gid}/feed"
+        data = {
+            "link": link,
+            "access_token": ACCESS_TOKEN,
+        }
+        response = _post(url, data)
+        gid_post_id = response.get("id")
+        results.append(gid_post_id)
+        logger.info(f"Post {post_id} shared to group {gid} as {gid_post_id}")
+    return results

--- a/tests/test_facebook_api.py
+++ b/tests/test_facebook_api.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import patch
+
+from facebook_post import facebook_api as fb
+
+
+class FacebookApiTests(unittest.TestCase):
+    @patch.object(fb, "PAGE_ID", "123")
+    @patch.object(fb, "ACCESS_TOKEN", "token")
+    @patch.object(fb, "_post")
+    def test_post_to_facebook_page_without_image(self, mock_post, *_):
+        mock_post.return_value = {"id": "post123"}
+        post_id = fb.post_to_facebook_page("hello world")
+        self.assertEqual(post_id, "post123")
+        mock_post.assert_called_once_with(
+            "https://graph.facebook.com/123/feed",
+            {"message": "hello world", "access_token": "token"},
+        )
+
+    @patch.object(fb, "PAGE_ID", "123")
+    @patch.object(fb, "ACCESS_TOKEN", "token")
+    @patch.object(fb, "_post")
+    def test_upload_image_to_page(self, mock_post, *_):
+        mock_post.return_value = {"id": "media123"}
+        media_id = fb._upload_image_to_page("http://image")
+        self.assertEqual(media_id, "media123")
+        mock_post.assert_called_once_with(
+            "https://graph.facebook.com/123/photos",
+            {"url": "http://image", "published": "false", "access_token": "token"},
+        )
+
+    @patch.object(fb, "PAGE_ID", "123")
+    @patch.object(fb, "ACCESS_TOKEN", "token")
+    @patch.object(fb, "_upload_image_to_page", return_value="media123")
+    @patch.object(fb, "_post")
+    def test_post_to_facebook_page_with_image(self, mock_post, mock_upload, *_):
+        mock_post.return_value = {"id": "post456"}
+        post_id = fb.post_to_facebook_page("hello", "http://image")
+        self.assertEqual(post_id, "post456")
+        mock_upload.assert_called_once_with("http://image")
+        expected_data = {
+            "message": "hello",
+            "access_token": "token",
+            "attached_media[0]": "{\"media_fbid\": \"media123\"}",
+        }
+        mock_post.assert_called_once_with(
+            "https://graph.facebook.com/123/feed",
+            expected_data,
+        )
+
+    @patch.object(fb, "PAGE_ID", "123")
+    @patch.object(fb, "ACCESS_TOKEN", "token")
+    @patch.object(fb, "_post")
+    def test_cross_post_to_groups(self, mock_post, *_):
+        mock_post.side_effect = [
+            {"id": "g1"},
+            {"id": "g2"},
+        ]
+        ids = fb.cross_post_to_groups("pagepost", ["1", "2"])
+        self.assertEqual(ids, ["g1", "g2"])
+        expected_calls = [
+            ("https://graph.facebook.com/1/feed", {"link": "https://www.facebook.com/pagepost", "access_token": "token"}),
+            ("https://graph.facebook.com/2/feed", {"link": "https://www.facebook.com/pagepost", "access_token": "token"}),
+        ]
+        self.assertEqual(mock_post.call_args_list, [((u, d),) for u, d in expected_calls])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add helper to publish posts to a Facebook page via Graph API
- allow unpublished image upload and cross-posting to groups
- cover functionality with unit tests

## Testing
- `python -m unittest tests.test_facebook_api -v`
- `python -m unittest discover -s tests -v` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a448fb68008325aa84ce5e8ad35c13