### PR TITLE
Remove user filter for Telegram callback handler

### DIFF
--- a/services/telegram_service.py
+++ b/services/telegram_service.py
@@ -28,9 +28,7 @@ class TelegramService:
                 filters.VOICE & filters.User(self.allowed_user_id), self._voice_handler
             )
         )
-        self.app.add_handler(
-            CallbackQueryHandler(self._callback_handler, filters.User(self.allowed_user_id))
-        )
+        self.app.add_handler(CallbackQueryHandler(self._callback_handler))
         self.loop: asyncio.AbstractEventLoop | None = None
         self._voice_future: asyncio.Future[str] | None = None
         self._callback_future: asyncio.Future[str] | None = None


### PR DESCRIPTION
## Summary
- drop User filter from Telegram callback handler and rely on `_callback_handler` for authorization

## Testing
- `pytest -q` *(fails: network unreachable when contacting Odoo)*

------
https://chatgpt.com/codex/tasks/task_e_68a46b5a3e4c8325be681763cd6e8f45