### PR TITLE
feat: show image previews and diversify generation

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -2,7 +2,7 @@
 
 Le script invite l'utilisateur à envoyer un message vocal et construit un post
 à partir de la transcription obtenue. Les interactions utilisateurs sont
-réalisées via la console pour simplifier l'exemple.
+désormais réalisées via un véritable bot Telegram.
 """
 
 from services.openai_service import OpenAIService
@@ -16,6 +16,7 @@ def main() -> None:
 
     openai_service = OpenAIService(logger)
     telegram_service = TelegramService(logger, openai_service)
+    telegram_service.start()
     facebook_service = FacebookService(logger)
 
     telegram_service.send_message("Il est temps de publier Kevin")
@@ -33,7 +34,7 @@ def main() -> None:
             if telegram_service.ask_yes_no("Générer des illustrations ?"):
                 illustrations = openai_service.generate_illustrations(choice)
                 if illustrations:
-                    selected_image = telegram_service.ask_options(
+                    selected_image = telegram_service.ask_image(
                         "Choisissez l'illustration", illustrations
                     )
 

--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -1,40 +1,66 @@
+from io import BytesIO
+import base64
 from typing import List
+
+from openai import OpenAI
 
 
 class OpenAIService:
-    """Service simulant les appels à l'API OpenAI."""
+    """Service d'accès à l'API OpenAI pour la génération et la transcription."""
 
     def __init__(self, logger) -> None:
         self.logger = logger
+        self.client = OpenAI()
 
     def generate_post_versions(self, text: str) -> List[str]:
-        """Génère plusieurs versions d'un message."""
+        """Génère plusieurs versions distinctes d'un message."""
         try:
-            return [f"{text}", f"{text} (variante)"]
+            prompt = (
+                "Propose trois versions différentes et concises d'un post basé sur le texte suivant:\n"
+                f"{text}"
+            )
+            response = self.client.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            content = response.choices[0].message.content.strip()
+            versions = [v.strip("- ") for v in content.split("\n") if v.strip()]
+            return versions[:3]
         except Exception as err:  # pragma: no cover - log then ignore
             self.logger.error(f"Erreur lors de la génération des versions : {err}")
             return []
 
     def generate_illustrations(self, text: str) -> List[str]:
-        """Génère une liste de noms d'illustrations fictives."""
+        """Génère des illustrations via l'API d'images d'OpenAI et renvoie les chemins."""
         try:
-            return ["image1.png", "image2.png"]
-        except Exception as err:  # pragma: no cover - log then ignore
-            self.logger.error(
-                f"Erreur lors de la génération des illustrations : {err}"
+            response = self.client.images.generate(
+                model="gpt-image-1",
+                prompt=text,
+                n=2,
+                size="512x512",
+                response_format="b64_json",
             )
+            paths: List[str] = []
+            for i, data in enumerate(response.data):
+                image_bytes = base64.b64decode(data.b64_json)
+                file_path = f"illustration_{i}.png"
+                with open(file_path, "wb") as f:
+                    f.write(image_bytes)
+                paths.append(file_path)
+            return paths
+        except Exception as err:  # pragma: no cover - log then ignore
+            self.logger.error(f"Erreur lors de la génération des illustrations : {err}")
             return []
 
     def transcribe_audio(self, audio_data: bytes) -> str:
-        """Transcrit un contenu audio en texte.
-
-        Dans cette implémentation simplifiée, ``audio_data`` représente les
-        données brutes du message vocal. La transcription est simulée en
-        décodant ces octets en UTF-8. En cas d'erreur, une chaîne vide est
-        retournée.
-        """
+        """Transcrit un contenu audio en texte via Whisper."""
         try:
-            return audio_data.decode("utf-8").strip()
+            audio_file = BytesIO(audio_data)
+            response = self.client.audio.transcriptions.create(
+                model="whisper-1",
+                file=("voice.ogg", audio_file, "audio/ogg"),
+            )
+            return response.text.strip()
         except Exception as err:  # pragma: no cover - log then ignore
             self.logger.error(f"Erreur lors de la transcription audio : {err}")
             return ""


### PR DESCRIPTION
## Summary
- add Telegram helper to send image previews with inline selection
- integrate OpenAI API for transcription, post variations and illustration generation
- update workflow to display illustration previews

## Testing
- `pip install openai python-telegram-bot`
- `pytest` *(fails: OSError: [Errno 101] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a45f96388c8325974b76b70d076e09