### PR TITLE
feat: implement facebook posting

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -6,3 +6,5 @@ load_dotenv()
 
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_USER_ID = int(os.getenv("TELEGRAM_USER_ID", "0"))
+FACEBOOK_PAGE_ID = os.getenv("FACEBOOK_PAGE_ID", "")
+FACEBOOK_PAGE_TOKEN = os.getenv("FACEBOOK_PAGE_TOKEN", "")


### PR DESCRIPTION
## Summary
- add facebook page id and token configuration
- implement posting to facebook pages and groups with error handling

## Testing
- `pytest` *(fails: Network is unreachable when connecting to Odoo)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b72fa564832593685ea4b1d24665