### PR TITLE
Map Telegram callbacks to options and images

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -38,8 +38,7 @@ def main() -> None:
             if telegram_service.ask_yes_no("Générer des illustrations ?"):
                 illustrations = openai_service.generate_illustrations(choice)
                 if illustrations:
-                    idx = telegram_service.ask_image(illustrations)
-                    selected_image = illustrations[idx]
+                    selected_image = telegram_service.ask_image(illustrations)
 
             facebook_service.post_to_facebook_page(choice, selected_image)
             groups = telegram_service.ask_groups()

--- a/tests/test_telegram_service.py
+++ b/tests/test_telegram_service.py
@@ -6,7 +6,7 @@ from services.telegram_service import TelegramService
 
 
 @patch("services.telegram_service.Application")
-def test_ask_image_returns_selected_index(mock_app):
+def test_ask_image_returns_selected_image(mock_app):
     builder = MagicMock()
     builder.token.return_value = builder
     app = MagicMock()
@@ -29,6 +29,6 @@ def test_ask_image_returns_selected_index(mock_app):
         return await task
 
     result = loop.run_until_complete(runner())
-    assert result == 1
+    assert result is images[1]
     assert app.bot.send_photo.await_count == 2
     loop.close()


### PR DESCRIPTION
## Summary
- Use numeric mapping for Telegram option buttons to avoid long callback data and return selected option
- Map image callbacks to image objects and expose the chosen image directly
- Update workflow and tests to use the returned image object

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4bc5370108325a8320525bf54e9cc