### PR TITLE
Handle illustration streams in memory

### DIFF
--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -1,3 +1,4 @@
+import base64
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
@@ -51,7 +52,32 @@ def test_generate_post_versions(monkeypatch):
     assert "versions DISTINCTES" in prompt
 
 @patch("services.openai_service.OpenAI")
-def test_generate_illustrations_returns_bytesio(mock_client):
+def test_generate_illustrations_returns_bytesio(mock_openai):
+    mock_client = MagicMock()
+    mock_openai.return_value = mock_client
+    mock_client.images.generate.return_value = type(
+        "Resp",
+        (),
+        {
+            "data": [
+                type(
+                    "Data",
+                    (),
+                    {
+                        "b64_json": base64.b64encode(b"img1").decode("utf-8")
+                    },
+                )(),
+                type(
+                    "Data",
+                    (),
+                    {
+                        "b64_json": base64.b64encode(b"img2").decode("utf-8")
+                    },
+                )(),
+            ]
+        },
+    )()
+
     service = OpenAIService(MagicMock())
     images = service.generate_illustrations("prompt")
     assert len(images) == 2

--- a/tests/test_telegram_service.py
+++ b/tests/test_telegram_service.py
@@ -23,7 +23,7 @@ def test_ask_image_returns_selected_image(mock_app):
     images = [BytesIO(b"a"), BytesIO(b"b")]
 
     async def runner():
-        task = asyncio.create_task(service._ask_images(images))
+        task = asyncio.create_task(service._ask_images("prompt", images))
         await asyncio.sleep(0)
         service._callback_future.set_result("1")
         return await task
@@ -31,4 +31,5 @@ def test_ask_image_returns_selected_image(mock_app):
     result = loop.run_until_complete(runner())
     assert result is images[1]
     assert app.bot.send_photo.await_count == 2
+    assert app.bot.send_message.await_count == 1
     loop.close()


### PR DESCRIPTION
## Summary
- Decode OpenAI image responses into BytesIO streams instead of writing files
- Ask Telegram users to choose illustrations with a prompt and short callbacks
- Save selected illustrations to disk before Facebook publishing and update tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4be9419e88325b60029fafe0323cb