### PR TITLE
Return OpenAI images as in-memory streams

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -44,12 +44,12 @@ class OpenAIService:
                 prompt=text,
                 size="1024x1024",
                 n=2,
-                response_format="b64_json",
             )
 
             images: List[BytesIO] = []
             for data in response.data:
-                images.append(BytesIO(base64.b64decode(data.b64_json)))
+                img_stream = BytesIO(base64.b64decode(data.b64_json))
+                images.append(img_stream)
             return images
         except Exception as err:  # pragma: no cover - log then ignore
             self.logger.error(


### PR DESCRIPTION
## Summary
- Remove deprecated response_format argument when generating images
- Convert received image data to BytesIO streams and return them

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c123d91483259e02c175a98cec47