### PR TITLE
feat: validate Facebook credentials

### DIFF
--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -25,14 +25,20 @@ class FacebookService:
         self, message: str, image: Union[str, BytesIO, None] = None
     ) -> None:
         """Planifie un post sur la page Facebook principale."""
-        url = f"https://graph.facebook.com/{config.FACEBOOK_PAGE_ID}/photos"
-        data = {"caption": message, "access_token": config.FACEBOOK_PAGE_TOKEN}
+        page_id = getattr(config, "FACEBOOK_PAGE_ID", "")
+        page_token = getattr(config, "FACEBOOK_PAGE_TOKEN", "")
+        if not page_id or not page_token:
+            msg = "FACEBOOK_PAGE_ID or FACEBOOK_PAGE_TOKEN is missing in config"
+            self.logger.error(msg)
+            raise ValueError(msg)
+
+        url = f"https://graph.facebook.com/{page_id}/photos"
+        data = {"caption": message, "access_token": page_token}
         files, fh = self._prepare_files(image)
         try:
-            requests.post(url, data=data, files=files, timeout=10).raise_for_status()
-            self.logger.info(
-                f"Publication planifiée sur la page : {message} (image={image})"
-            )
+            response = requests.post(url, data=data, files=files, timeout=10)
+            response.raise_for_status()
+            self.logger.info(f"Facebook page response: {response.text}")
         except Exception as e:
             self.logger.error(
                 f"Erreur lors de la publication sur la page Facebook : {e}"
@@ -45,14 +51,21 @@ class FacebookService:
         self, message: str, groups: List[str], image: Union[str, BytesIO, None] = None
     ) -> None:
         """Diffuse le message dans les groupes donnés."""
+        page_token = getattr(config, "FACEBOOK_PAGE_TOKEN", "")
+        if not page_token:
+            msg = "FACEBOOK_PAGE_TOKEN is missing in config"
+            self.logger.error(msg)
+            raise ValueError(msg)
+
         for group in groups:
             url = f"https://graph.facebook.com/{group}/photos"
-            data = {"caption": message, "access_token": config.FACEBOOK_PAGE_TOKEN}
+            data = {"caption": message, "access_token": page_token}
             files, fh = self._prepare_files(image)
             try:
-                requests.post(url, data=data, files=files, timeout=10).raise_for_status()
+                response = requests.post(url, data=data, files=files, timeout=10)
+                response.raise_for_status()
                 self.logger.info(
-                    f"Publication envoyée au groupe {group} : {message} (image={image})"
+                    f"Réponse du groupe {group}: {response.text}"
                 )
             except Exception as e:
                 self.logger.error(


### PR DESCRIPTION
## Summary
- raise error if Facebook page ID or token missing
- log Facebook API responses when posting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c132e8f08325aada21af0641a787