### PR TITLE
feat: configurable OpenAI image model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Variables pour OpenAI
+OPENAI_API_KEY=<votre clef API OpenAI>
+# Définir un modèle accessible si l'organisation n'est pas vérifiée (ex: gpt-4o-mini)
+OPENAI_IMAGE_MODEL=gpt-image-1
+
+# Variables de connexion à Odoo
+ODOO_URL=<url de votre instance Odoo>
+ODOO_DB=<base de données>
+ODOO_USER=<utilisateur>
+ODOO_PASSWORD=<mot de passe>


### PR DESCRIPTION
## Summary
- read image model from OPENAI_IMAGE_MODEL env var
- handle InvalidRequestError when generating illustrations
- document required OPENAI_IMAGE_MODEL in .env.example
- add regression test for invalid image generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c30bb3b4832583338d2b267ebd18