### PR TITLE
Replace prints with shared logger

### DIFF
--- a/config/log_config.py
+++ b/config/log_config.py
@@ -41,11 +41,11 @@ def setup_logger():
                 logger.addHandler(stream_handler)
 
             except Exception as handler_error:
-                print(f"Erreur lors de la création des handlers de log : {handler_error}")
+                sys.stderr.write(f"Erreur lors de la création des handlers de log : {handler_error}\n")
                 raise
 
         return logger
 
     except Exception as e:
-        print(f"Impossible d'initialiser le logger : {e}")
+        sys.stderr.write(f"Impossible d'initialiser le logger : {e}\n")
         raise

--- a/generate_post/generate_facebook_post.py
+++ b/generate_post/generate_facebook_post.py
@@ -6,6 +6,9 @@ sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from config.openai_utils import chat_gpt
+from config.log_config import setup_logger
+
+logger = setup_logger()
 
 # Construction du chemin absolu vers le fichier de prompt
 prompt_path = os.path.join(os.path.dirname(__file__), 'prompts', 'facebook.txt')
@@ -15,6 +18,6 @@ with open(prompt_path, 'r', encoding='utf-8') as f:
 reponse = chat_gpt(facebook_prompt)
 
 if reponse:
-    print(reponse)
+    logger.info(reponse)
 else:
-    print("Une erreur est survenue lors de l'appel à l'API OpenAI. Consulte le fichier de log.")
+    logger.error("Une erreur est survenue lors de l'appel à l'API OpenAI. Consulte le fichier de log.")

--- a/generate_post/generate_linkedin_post.py
+++ b/generate_post/generate_linkedin_post.py
@@ -1,7 +1,12 @@
 import sys
 import os
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from config.openai_utils import chat_gpt
+from config.log_config import setup_logger
+
+logger = setup_logger()
 
 # Construction du chemin absolu vers le fichier de prompt
 prompt_path = os.path.join(os.path.dirname(__file__), 'prompts', 'linkedin.txt')
@@ -11,6 +16,6 @@ with open(prompt_path, 'r', encoding='utf-8') as f:
 reponse = chat_gpt(linkedin_prompt)
 
 if reponse:
-    print(reponse)
+    logger.info(reponse)
 else:
-    print("Une erreur est survenue lors de l'appel à l'API OpenAI. Consulte le fichier de log.")
+    logger.error("Une erreur est survenue lors de l'appel à l'API OpenAI. Consulte le fichier de log.")

--- a/tests/test_openai_integration.py
+++ b/tests/test_openai_integration.py
@@ -1,9 +1,12 @@
 from config.openai_utils import chat_gpt
+from config.log_config import setup_logger
+
+logger = setup_logger()
 
 question = "Donne-moi un exemple de prompt pour Odoo."
 reponse = chat_gpt(question)
 
 if reponse:
-    print(reponse)
+    logger.info(reponse)
 else:
-    print("Une erreur est survenue lors de l'appel à l'API OpenAI. Consulte le fichier de log.")
+    logger.error("Une erreur est survenue lors de l'appel à l'API OpenAI. Consulte le fichier de log.")


### PR DESCRIPTION
## Summary
- Use centralized logger in LinkedIn and Facebook post generators
- Log responses and errors in OpenAI integration test
- Write logging setup errors to stderr instead of using print

## Testing
- `pytest -q` *(fails: AttributeError: module 'config' has no attribute 'FACEBOOK_PAGE_TOKEN')*

------
https://chatgpt.com/codex/tasks/task_e_68a4d63e71748325aa5129241fe5e689