### PR TITLE
Log exceptions with stack traces

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -22,7 +22,7 @@ def main() -> None:
     try:
         facebook_service = FacebookService(logger)
     except RuntimeError as err:
-        logger.error(f"Initialisation du service Facebook échouée : {err}")
+        logger.exception(f"Initialisation du service Facebook échouée : {err}")
         telegram_service.send_message(str(err))
         return
 
@@ -60,7 +60,7 @@ def main() -> None:
 
             logger.info("Publication terminée avec succès.")
         except Exception as err:  # pragma: no cover - log then continue
-            logger.error(f"Erreur lors du traitement : {err}")
+            logger.exception(f"Erreur lors du traitement : {err}")
 
 
 if __name__ == "__main__":

--- a/config/group_data_loader.py
+++ b/config/group_data_loader.py
@@ -18,5 +18,5 @@ def load_group_data(file_name="group_data.json"):
         logger.info(f"Données de groupe chargées depuis {file_path}.")
         return data
     except Exception as e:
-        logger.error(f"Erreur lors du chargement des données de groupe : {e}")
+        logger.exception(f"Erreur lors du chargement des données de groupe : {e}")
         return {}

--- a/config/odoo_connect.py
+++ b/config/odoo_connect.py
@@ -91,5 +91,5 @@ def get_odoo_connection():
         return db, uid, password, FAKE_MODELS
 
     except Exception as conn_error:
-        logger.error(f"Erreur lors de la connexion à Odoo : {conn_error}")
+        logger.exception(f"Erreur lors de la connexion à Odoo : {conn_error}")
         raise

--- a/config/openai_utils.py
+++ b/config/openai_utils.py
@@ -45,7 +45,7 @@ def chat_gpt(prompt, model="gpt-4.1", system_prompt=prompt_system):
         logger.info("Réponse OpenAI reçue avec succès.")
         return content
     except Exception as e:
-        logger.error(f"Erreur lors de l'appel OpenAI : {e}")
+        logger.exception(f"Erreur lors de l'appel OpenAI : {e}")
         return None
 
 
@@ -88,7 +88,7 @@ def generate_illustrations(prompt_text):
                 urls.append(url)
         return urls
     except Exception as e:
-        logger.error(f"Erreur lors de la génération d'images : {e}")
+        logger.exception(f"Erreur lors de la génération d'images : {e}")
         return []
 
 # --- Audio transcription utilities -------------------------------------------------
@@ -146,7 +146,7 @@ def transcribe_audio(path: str) -> Optional[str]:
 
         return text
     except Exception as e:
-        logger.error(f"Erreur lors de la transcription audio : {e}")
+        logger.exception(f"Erreur lors de la transcription audio : {e}")
         return None
 
 

--- a/pos_category_management/manage_pos_categories.py
+++ b/pos_category_management/manage_pos_categories.py
@@ -102,7 +102,7 @@ def update_pos_categories(current_dt: datetime | None = None):
         categories = fetch_all_categories(models, db, uid, password)
         logger.info("Catégories POS existantes : %s", categories)
     except Exception as err:
-        logger.error("Impossible de récupérer les catégories POS : %s", err)
+        logger.exception("Impossible de récupérer les catégories POS : %s", err)
 
     to_activate, to_deactivate = compute_category_actions(current_dt)
 
@@ -120,7 +120,7 @@ def update_pos_categories(current_dt: datetime | None = None):
                 name = "FOURNIL"
             logger.info("Catégorie POS activée : %s", f"{category_id} {name}")
         except Exception as err:
-            logger.error(
+            logger.exception(
                 "Erreur lors de l'activation de la catégorie %s : %s",
                 category_id,
                 err,
@@ -140,7 +140,7 @@ def update_pos_categories(current_dt: datetime | None = None):
                 name = "FOURNIL"
             logger.info("Catégorie POS désactivée : %s", f"{category_id} {name}")
         except Exception as err:
-            logger.error(
+            logger.exception(
                 "Erreur lors de la désactivation de la catégorie %s : %s",
                 category_id,
                 err,

--- a/schedule_post_in_odoo/schedule_facebook_post.py
+++ b/schedule_post_in_odoo/schedule_facebook_post.py
@@ -32,7 +32,7 @@ def get_facebook_stream_id(models, db, uid, password):
         logger.info(f"Flux Facebook sélectionné : {streams[0]['name']} (ID {stream_id})")
         return stream_id
     except Exception as e:
-        logger.error(f"Erreur lors de la récupération du flux Facebook : {e}")
+        logger.exception(f"Erreur lors de la récupération du flux Facebook : {e}")
         raise
 
 def schedule_post(models, db, uid, password, stream_id, message, minutes_later=30):
@@ -52,7 +52,9 @@ def schedule_post(models, db, uid, password, stream_id, message, minutes_later=3
         logger.info(f"Publication Facebook planifiée avec succès (ID {post_id}), à {scheduled_date}")
         return post_id
     except Exception as e:
-        logger.error(f"Erreur lors de la planification de la publication Facebook : {e}")
+        logger.exception(
+            f"Erreur lors de la planification de la publication Facebook : {e}"
+        )
         raise
 
 def main():
@@ -63,7 +65,7 @@ def main():
         schedule_post(models, db, uid, password, stream_id, post_message)
         logger.info("Script terminé avec succès.")
     except Exception as err:
-        logger.error(f"Échec du script : {err}")
+        logger.exception(f"Échec du script : {err}")
 
 if __name__ == "__main__":
     main()

--- a/services/audio_service.py
+++ b/services/audio_service.py
@@ -31,7 +31,7 @@ class AudioService:
             self.logger.info(f"Fichier audio transcrit : {file_path}")
             return text, file_path
         except Exception as err:  # pragma: no cover - log then ignore
-            self.logger.error(f"Erreur lors de la transcription audio : {err}")
+            self.logger.exception(f"Erreur lors de la transcription audio : {err}")
             return None
 
     def delete_file(self, file_path: str) -> None:
@@ -42,6 +42,6 @@ class AudioService:
             os.remove(file_path)
             self.logger.info(f"Fichier supprimé : {file_path}")
         except OSError as err:  # pragma: no cover - log then ignore
-            self.logger.error(
+            self.logger.exception(
                 f"Erreur lors de la suppression du fichier {file_path}: {err}"
             )

--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -39,7 +39,7 @@ class FacebookService:
             response.raise_for_status()
             self.logger.info(f"Facebook page response: {response.text}")
         except Exception as e:
-            self.logger.error(
+            self.logger.exception(
                 f"Erreur lors de la publication sur la page Facebook : {e}"
             )
         finally:
@@ -61,7 +61,7 @@ class FacebookService:
                     f"Réponse du groupe {group}: {response.text}"
                 )
             except Exception as e:
-                self.logger.error(
+                self.logger.exception(
                     f"Erreur lors de la publication dans le groupe {group} : {e}"
                 )
             finally:

--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -32,7 +32,9 @@ class OpenAIService:
             content = response.choices[0].message.content
             return [v.strip() for v in content.split("---") if v.strip()]
         except Exception as err:  # pragma: no cover - log then ignore
-            self.logger.error(f"Erreur lors de la génération des versions : {err}")
+            self.logger.exception(
+                f"Erreur lors de la génération des versions : {err}"
+            )
             return []
 
     def generate_illustrations(self, prompt: str) -> List[BytesIO]:
@@ -56,10 +58,10 @@ class OpenAIService:
                 images.append(img_stream)
             return images
         except openai.error.InvalidRequestError as err:
-            self.logger.error(f"Erreur de génération d’images : {err}")
+            self.logger.exception(f"Erreur de génération d’images : {err}")
             return []
         except Exception as err:  # pragma: no cover - log then ignore
-            self.logger.error(
+            self.logger.exception(
                 f"Erreur lors de la génération des illustrations : {err}"
             )
             return []
@@ -75,7 +77,7 @@ class OpenAIService:
             )
             return response.text.strip()
         except Exception as err:  # pragma: no cover - log then ignore
-            self.logger.error(
+            self.logger.exception(
                 f"Erreur lors de la transcription audio : {err}"
             )
             return ""


### PR DESCRIPTION
## Summary
- replace logger.error with logger.exception in exception handlers
- ensure all services log stack traces when failures occur

## Testing
- `pytest -q` *(fails: AttributeError: module 'config' has no attribute 'FACEBOOK_PAGE_TOKEN')*

------
https://chatgpt.com/codex/tasks/task_e_68a4d634cc548325af9f9eee7939057c