### PR TITLE
feat: add execution logging decorator

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -10,9 +10,10 @@ from services.openai_service import OpenAIService
 import asyncio
 from services.telegram_service import TelegramService
 from services.facebook_service import FacebookService
-from config.log_config import setup_logger
+from config.log_config import setup_logger, log_execution
 
 
+@log_execution
 def main() -> None:
     logger = setup_logger()
 

--- a/config/log_config.py
+++ b/config/log_config.py
@@ -3,6 +3,9 @@
 import logging
 import os
 import sys
+import inspect
+import asyncio
+from functools import wraps
 
 def setup_logger():
     """
@@ -49,3 +52,53 @@ def setup_logger():
     except Exception as e:
         print(f"Impossible d'initialiser le logger : {e}")
         raise
+
+
+def log_execution(func):
+    """Decorator logging function entry and exit with location information."""
+
+    async def _log_async(*args, **kwargs):
+        logger = logging.getLogger("odoo_automation")
+        cls_name = None
+        if args:
+            obj = args[0]
+            if hasattr(obj, func.__name__):
+                cls_name = obj.__class__.__name__
+        source_file = inspect.getsourcefile(func) or "<unknown>"
+        line_no = inspect.getsourcelines(func)[1]
+        name = f"{cls_name + '.' if cls_name else ''}{func.__name__}"
+        logger.info(f"Starting {name} ({source_file}:{line_no})")
+        try:
+            return await func(*args, **kwargs)
+        finally:
+            logger.info(f"Completed {name} ({source_file}:{line_no})")
+
+    def _log_sync(*args, **kwargs):
+        logger = logging.getLogger("odoo_automation")
+        cls_name = None
+        if args:
+            obj = args[0]
+            if hasattr(obj, func.__name__):
+                cls_name = obj.__class__.__name__
+        source_file = inspect.getsourcefile(func) or "<unknown>"
+        line_no = inspect.getsourcelines(func)[1]
+        name = f"{cls_name + '.' if cls_name else ''}{func.__name__}"
+        logger.info(f"Starting {name} ({source_file}:{line_no})")
+        try:
+            return func(*args, **kwargs)
+        finally:
+            logger.info(f"Completed {name} ({source_file}:{line_no})")
+
+    if asyncio.iscoroutinefunction(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            return await _log_async(*args, **kwargs)
+
+        return wrapper
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return _log_sync(*args, **kwargs)
+
+    return wrapper
+

--- a/facebook_post/facebook_api.py
+++ b/facebook_post/facebook_api.py
@@ -3,13 +3,14 @@ from urllib import request, parse
 
 import config
 from config.log_config import setup_logger
+from config.log_config import log_execution
 
 logger = setup_logger()
 GRAPH_API_URL = "https://graph.facebook.com"
 
 # Retrieve credentials from the central configuration
 PAGE_ID = config.FACEBOOK_PAGE_ID
-ACCESS_TOKEN = config.FACEBOOK_PAGE_TOKEN
+ACCESS_TOKEN = config.PAGE_ACCESS_TOKEN
 
 
 def _post(url, data):
@@ -32,6 +33,7 @@ def _upload_image_to_page(image_url):
     logger.info(f"Image uploaded with media_fbid {media_id}")
     return media_id
 
+@log_execution
 def post_to_facebook_page(message, image_url=None):
     """Post a message to the Facebook page and return its post_id."""
     url = f"{GRAPH_API_URL}/{PAGE_ID}/feed"
@@ -47,6 +49,7 @@ def post_to_facebook_page(message, image_url=None):
     logger.info(f"Post published with id {post_id}")
     return post_id
 
+@log_execution
 def cross_post_to_groups(post_id, group_ids):
     """Cross-post an existing page post to multiple Facebook groups."""
     results = []

--- a/pos_category_management/manage_pos_categories.py
+++ b/pos_category_management/manage_pos_categories.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from config.odoo_connect import get_odoo_connection
-from config.log_config import setup_logger
+from config.log_config import setup_logger, log_execution
 
 logger = setup_logger()
 
@@ -39,6 +39,7 @@ def _ensure_category_active(models, db, uid, password, category_id):
                 [[config_ids[0]], {"iface_available_categ_ids": [(4, category_id)]}],
             )
 
+@log_execution
 def fetch_all_categories(models, db, uid, password):
     """Return all POS categories with their IDs."""
     return models.execute_kw(
@@ -76,6 +77,7 @@ def _deactivate_category(models, db, uid, password, category_id):
             )
 
 
+@log_execution
 def compute_category_actions(
     current_dt: datetime,
 ) -> tuple[list[int], list[int]]:
@@ -92,6 +94,7 @@ def compute_category_actions(
     return [], SUNDAY_CATEGORY_IDS.copy()
 
 
+@log_execution
 def update_pos_categories(current_dt: datetime | None = None):
     """Update POS categories according to the current day and time."""
     if current_dt is None:

--- a/schedule_post_in_odoo/schedule_facebook_post.py
+++ b/schedule_post_in_odoo/schedule_facebook_post.py
@@ -9,7 +9,7 @@ Auteur : Kevin, Tech Aware
 """
 
 from datetime import datetime, timedelta
-from config.log_config import setup_logger
+from config.log_config import setup_logger, log_execution
 from config.odoo_connect import get_odoo_connection
 
 # Initialisation logging
@@ -17,6 +17,7 @@ logger = setup_logger()
 
 # === Configuration Odoo ===
 
+@log_execution
 def get_facebook_stream_id(models, db, uid, password):
     try:
         streams = models.execute_kw(
@@ -35,6 +36,7 @@ def get_facebook_stream_id(models, db, uid, password):
         logger.error(f"Erreur lors de la récupération du flux Facebook : {e}")
         raise
 
+@log_execution
 def schedule_post(models, db, uid, password, stream_id, message, minutes_later=30):
     try:
         scheduled_date = (datetime.utcnow() + timedelta(minutes=minutes_later)).strftime('%Y-%m-%d %H:%M:%S')
@@ -55,6 +57,7 @@ def schedule_post(models, db, uid, password, stream_id, message, minutes_later=3
         logger.error(f"Erreur lors de la planification de la publication Facebook : {e}")
         raise
 
+@log_execution
 def main():
     try:
         db, uid, password, models = get_odoo_connection()

--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -3,11 +3,13 @@ from io import BytesIO
 
 import config
 import requests
+from config.log_config import log_execution
 
 
 class FacebookService:
     """Service simulant la publication sur Facebook."""
 
+    @log_execution
     def __init__(self, logger) -> None:
         self.logger = logger
         if not config.FACEBOOK_PAGE_ID or not config.PAGE_ACCESS_TOKEN:
@@ -27,6 +29,7 @@ class FacebookService:
             return {"source": fh}, fh
         return None, None
 
+    @log_execution
     def post_to_facebook_page(
         self, message: str, image: Union[str, BytesIO, None] = None
     ) -> None:
@@ -46,6 +49,7 @@ class FacebookService:
             if fh:
                 fh.close()
 
+    @log_execution
     def cross_post_to_groups(
         self, message: str, groups: List[str], image: Union[str, BytesIO, None] = None
     ) -> None:

--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -5,6 +5,7 @@ from typing import List
 
 import openai
 from openai import OpenAI
+from config.log_config import log_execution
 
 
 class OpenAIService:
@@ -12,10 +13,12 @@ class OpenAIService:
 
     IMAGE_MODEL = os.getenv("OPENAI_IMAGE_MODEL", "gpt-image-1")
 
+    @log_execution
     def __init__(self, logger) -> None:
         self.logger = logger
         self.client = OpenAI()
 
+    @log_execution
     def generate_post_versions(self, text: str) -> List[str]:
         """Génère plusieurs versions d'un message."""
         prompt = (
@@ -35,6 +38,7 @@ class OpenAIService:
             self.logger.error(f"Erreur lors de la génération des versions : {err}")
             return []
 
+    @log_execution
     def generate_illustrations(self, prompt: str) -> List[BytesIO]:
         """Génère une liste d'illustrations en mémoire.
 
@@ -64,6 +68,7 @@ class OpenAIService:
             )
             return []
 
+    @log_execution
     def transcribe_audio(self, audio_data: bytes) -> str:
         """Transcrit un contenu audio en texte via le modèle Whisper."""
 

--- a/services/telegram_service.py
+++ b/services/telegram_service.py
@@ -14,11 +14,13 @@ from telegram.ext import (
 )
 
 import config
+from config.log_config import log_execution
 
 
 class TelegramService:
     """Service d'interaction via Telegram basé sur python-telegram-bot."""
 
+    @log_execution
     def __init__(self, logger, openai_service: Optional["OpenAIService"] = None) -> None:
         self.logger = logger
         self.openai_service = openai_service
@@ -38,6 +40,7 @@ class TelegramService:
     # ------------------------------------------------------------------
     # Gestion du bot
     # ------------------------------------------------------------------
+    @log_execution
     def start(self) -> None:
         if self._thread and self._thread.is_alive():
             return
@@ -59,6 +62,7 @@ class TelegramService:
     # ------------------------------------------------------------------
     # Envoi de messages
     # ------------------------------------------------------------------
+    @log_execution
     def send_message(self, text: str) -> None:
         if not self.loop:
             raise RuntimeError("Le bot Telegram n'est pas démarré")
@@ -87,6 +91,7 @@ class TelegramService:
         self._voice_future = self.loop.create_future()
         return await self._voice_future
 
+    @log_execution
     def wait_for_voice_message(self) -> str:
         if not self.loop:
             raise RuntimeError("Le bot Telegram n'est pas démarré")
@@ -119,6 +124,7 @@ class TelegramService:
         answer_key = await self._callback_future
         return mapping[answer_key]
 
+    @log_execution
     def ask_options(self, prompt: str, options: List[str]) -> str:
         if not self.loop:
             raise RuntimeError("Le bot Telegram n'est pas démarré")
@@ -126,10 +132,12 @@ class TelegramService:
             self._ask(prompt, options), self.loop
         ).result()
 
+    @log_execution
     def ask_yes_no(self, prompt: str) -> bool:
         response = self.ask_options(prompt, ["Oui", "Non"])
         return response == "Oui"
 
+    @log_execution
     def ask_groups(self) -> List[str]:
         groups = []
         data = config.load_group_data()
@@ -163,6 +171,7 @@ class TelegramService:
         answer_key = await self._callback_future
         return mapping[answer_key]
 
+    @log_execution
     def ask_image(self, prompt: str, images: List[BytesIO]) -> BytesIO:
         """Demande à l'utilisateur de choisir une image parmi celles fournies."""
         if not self.loop:


### PR DESCRIPTION
## Summary
- add reusable async-aware execution logging decorator
- apply decorator to services and workflow scripts
- fix Facebook token configuration constant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d642f4c0832583c9c034eaa8e156