### PR TITLE
Use module-specific loggers for better traceability

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -14,7 +14,7 @@ from config.log_config import setup_logger
 
 
 def main() -> None:
-    logger = setup_logger()
+    logger = setup_logger(__name__)
 
     openai_service = OpenAIService(logger)
     telegram_service = TelegramService(logger, openai_service)

--- a/config/auth.py
+++ b/config/auth.py
@@ -3,9 +3,11 @@
 from config.log_config import setup_logger
 
 
+logger = setup_logger(__name__)
+
+
 def authenticate_odoo(url, db, username, password):
     """Simule l'authentification Odoo pour les tests hors ligne."""
-    logger = setup_logger()
     logger.info("Tentative d'authentification Odoo...")
     if password == "mauvais_mot_de_passe":
         logger.error("Échec de l'authentification Odoo : identifiants invalides.")

--- a/config/group_data_loader.py
+++ b/config/group_data_loader.py
@@ -4,7 +4,7 @@ import json
 import os
 from .log_config import setup_logger
 
-logger = setup_logger()
+logger = setup_logger(__name__)
 
 def load_group_data(file_name="group_data.json"):
     """

--- a/config/log_config.py
+++ b/config/log_config.py
@@ -1,15 +1,14 @@
 # config/log_config.py
 
 import logging
-import os
 import sys
 
-def setup_logger():
-    """
-    Initialise et configure un logger qui écrit les messages dans un fichier log (UTF-8)
-    et les affiche aussi dans la console (UTF-8 si supporté).
-    Le logger permet de tracer tout ce qui se passe dans le script.
-    En cas d'erreur lors de la configuration, une exception est levée.
+
+def setup_logger(name: str) -> logging.Logger:
+    """Initialise un logger nommé et configure les handlers.
+
+    Les messages sont écrits dans un fichier log (UTF-8) et affichés dans la
+    console. Le format inclut le nom du module pour faciliter le suivi.
     """
     try:
         log_file = "odoo_automation.log"  # Nom du fichier log
@@ -19,29 +18,34 @@ def setup_logger():
         # os.makedirs(logs_dir, exist_ok=True)
         # log_file = os.path.join(logs_dir, "odoo_automation.log")
 
-        logger = logging.getLogger("odoo_automation")
-        logger.setLevel(logging.DEBUG)  # Capture tout (DEBUG et au-dessus)
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
 
-        # Pour éviter plusieurs handlers si la fonction est appelée plusieurs fois
-        if not logger.handlers:
+        root_logger = logging.getLogger()
+        if not root_logger.handlers:
             try:
                 # Handler fichier UTF-8
-                file_handler = logging.FileHandler(log_file, encoding='utf-8')
+                file_handler = logging.FileHandler(log_file, encoding="utf-8")
                 file_handler.setLevel(logging.DEBUG)
 
                 # Handler console (UTF-8 si supporté)
                 stream_handler = logging.StreamHandler(stream=sys.stdout)
                 stream_handler.setLevel(logging.INFO)
 
-                formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+                formatter = logging.Formatter(
+                    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+                )
                 file_handler.setFormatter(formatter)
                 stream_handler.setFormatter(formatter)
 
-                logger.addHandler(file_handler)
-                logger.addHandler(stream_handler)
+                root_logger.setLevel(logging.DEBUG)
+                root_logger.addHandler(file_handler)
+                root_logger.addHandler(stream_handler)
 
             except Exception as handler_error:
-                print(f"Erreur lors de la création des handlers de log : {handler_error}")
+                print(
+                    f"Erreur lors de la création des handlers de log : {handler_error}"
+                )
                 raise
 
         return logger

--- a/config/odoo_connect.py
+++ b/config/odoo_connect.py
@@ -5,6 +5,9 @@ from config.auth import authenticate_odoo
 from config import ODOO_URL, ODOO_DB, ODOO_USER, ODOO_PASSWORD
 
 
+logger = setup_logger(__name__)
+
+
 class FakeModels:
     def __init__(self):
         self.categories = {1: {"id": 1, "name": "Cat1", "parent_id": False}}
@@ -70,7 +73,6 @@ def get_odoo_connection():
     Utilise la fonction authenticate_odoo pour gérer l'authentification.
     Retourne : db, uid, password, models (proxy pour manipuler les objets Odoo)
     """
-    logger = setup_logger()
     logger.info("Démarrage de l'initialisation de la connexion à Odoo.")
 
     try:

--- a/config/openai_utils.py
+++ b/config/openai_utils.py
@@ -8,7 +8,7 @@ from .log_config import setup_logger  # Import du setup_logger depuis le même d
 from . import OPENAI_API_KEY
 
 # Initialise le logger via la config centrale
-logger = setup_logger()
+logger = setup_logger(__name__)
 
 # Configure the OpenAI client using the key provided in config
 if not OPENAI_API_KEY:

--- a/facebook_post/facebook_api.py
+++ b/facebook_post/facebook_api.py
@@ -4,12 +4,12 @@ from urllib import request, parse
 import config
 from config.log_config import setup_logger
 
-logger = setup_logger()
+logger = setup_logger(__name__)
 GRAPH_API_URL = "https://graph.facebook.com"
 
 # Retrieve credentials from the central configuration
 PAGE_ID = config.FACEBOOK_PAGE_ID
-ACCESS_TOKEN = config.FACEBOOK_PAGE_TOKEN
+ACCESS_TOKEN = config.PAGE_ACCESS_TOKEN
 
 
 def _post(url, data):

--- a/pos_category_management/manage_pos_categories.py
+++ b/pos_category_management/manage_pos_categories.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from config.odoo_connect import get_odoo_connection
 from config.log_config import setup_logger
 
-logger = setup_logger()
+logger = setup_logger(__name__)
 
 # Category identifiers used for automatic activation/deactivation.
 # These values come from the Odoo database and therefore are integers

--- a/schedule_post_in_odoo/schedule_facebook_post.py
+++ b/schedule_post_in_odoo/schedule_facebook_post.py
@@ -13,7 +13,7 @@ from config.log_config import setup_logger
 from config.odoo_connect import get_odoo_connection
 
 # Initialisation logging
-logger = setup_logger()
+logger = setup_logger(__name__)
 
 # === Configuration Odoo ===
 

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -3,10 +3,11 @@
 import unittest
 from config.log_config import setup_logger
 
+
 class TestLogger(unittest.TestCase):
     def setUp(self):
         # Initialisation du logger avant chaque test
-        self.logger = setup_logger()
+        self.logger = setup_logger(__name__)
 
     def test_info_log(self):
         try:


### PR DESCRIPTION
## Summary
- accept logger name in `setup_logger` and include module in log format
- update modules to call `setup_logger(__name__)`
- fix facebook API to use `PAGE_ACCESS_TOKEN`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d648418883258eae13b160921add