### PR TITLE
refactor: handle OpenAI errors

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -3,8 +3,7 @@ import os
 from io import BytesIO
 from typing import List
 
-import openai
-from openai import OpenAI
+from openai import OpenAI, OpenAIError
 from config.log_config import log_execution
 
 
@@ -61,7 +60,7 @@ class OpenAIService:
                 img_stream = BytesIO(base64.b64decode(data.b64_json))
                 images.append(img_stream)
             return images
-        except openai.error.InvalidRequestError as err:
+        except OpenAIError as err:
             self.logger.exception(f"Erreur de génération d’images : {err}")
             return []
         except Exception as err:  # pragma: no cover - log then ignore


### PR DESCRIPTION
## Summary
- replace deprecated openai module import with `OpenAI` client and `OpenAIError`
- handle `OpenAIError` when generating images

## Testing
- `pytest -q` *(fails: setup_logger() missing 1 required positional argument: 'name')*
- `pytest tests/test_openai_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4da734164832587c0b816cbfa4afe