### PR TITLE
Align OpenAI tests with new error classes

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -61,7 +61,7 @@ class OpenAIService:
                 img_stream = BytesIO(base64.b64decode(data.b64_json))
                 images.append(img_stream)
             return images
-        except openai.error.InvalidRequestError as err:
+        except openai.OpenAIError as err:
             self.logger.exception(f"Erreur de génération d’images : {err}")
             return []
         except Exception as err:  # pragma: no cover - log then ignore

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -1,6 +1,5 @@
 import base64
 from io import BytesIO
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import openai
@@ -88,14 +87,9 @@ def test_generate_illustrations_returns_bytesio(mock_openai):
 
 @patch("services.openai_service.OpenAI")
 def test_generate_illustrations_invalid_request(mock_openai):
-    class DummyInvalidRequestError(Exception):
-        pass
-
-    openai.error = SimpleNamespace(InvalidRequestError=DummyInvalidRequestError)
-
     mock_client = MagicMock()
     mock_openai.return_value = mock_client
-    mock_client.images.generate.side_effect = DummyInvalidRequestError("bad request")
+    mock_client.images.generate.side_effect = openai.OpenAIError("bad request")
 
     service = OpenAIService(MagicMock())
     result = service.generate_illustrations("prompt")


### PR DESCRIPTION
## Summary
- Catch `openai.OpenAIError` in `OpenAIService.generate_illustrations`
- Update tests to raise real `openai.OpenAIError` instead of mock namespace

## Testing
- ❌ `pytest -q` (TypeError: setup_logger() missing 1 required positional argument: 'name')
- ✅ `pytest tests/test_openai_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4da77cfc483258b95df0a8290cd77