### PR TITLE
Refactor OpenAI error handling

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -60,7 +60,7 @@ class OpenAIService:
                 img_stream = BytesIO(base64.b64decode(data.b64_json))
                 images.append(img_stream)
             return images
-        except openai.OpenAIError as err:
+        except OpenAIError as err:
 
             self.logger.exception(f"Erreur de génération d’images : {err}")
             return []


### PR DESCRIPTION
## Summary
- reference OpenAIError directly for image generation error handling

## Testing
- `pytest tests/test_openai_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4e2afd37c832586552506e81544c3