### PR TITLE
Use FACEBOOK_PAGE_ID env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ ODOO_PASSWORD=<mot de passe>
 TELEGRAM_BOT_TOKEN=<token du bot Telegram>
 TELEGRAM_USER_ID=<identifiant Telegram du destinataire>
 FACEBOOK_PAGE_ID=<id de votre page Facebook>
-FACEBOOK_PAGE_TOKEN=<token de la page Facebook>
+PAGE_ACCESS_TOKEN=<token de la page Facebook>
 ```
 
-Ces variables permettent de se connecter à Odoo, à l'API OpenAI, à Facebook et à Telegram pour l'envoi de notifications. `TELEGRAM_BOT_TOKEN` et `TELEGRAM_USER_ID` sont utilisés par `services/telegram_service.py` pour envoyer des messages, tandis que `FACEBOOK_PAGE_ID` et `FACEBOOK_PAGE_TOKEN` servent aux modules de publication Facebook.
+Ces variables permettent de se connecter à Odoo, à l'API OpenAI, à Facebook et à Telegram pour l'envoi de notifications. `TELEGRAM_BOT_TOKEN` et `TELEGRAM_USER_ID` sont utilisés par `services/telegram_service.py` pour envoyer des messages, tandis que `FACEBOOK_PAGE_ID` et `PAGE_ACCESS_TOKEN` servent aux modules de publication Facebook.
 
 ## Utilisation principale
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -31,5 +31,5 @@ TELEGRAM_USER_ID = int(os.getenv("TELEGRAM_USER_ID", "0"))
 
 # --- Facebook configuration ---------------------------------------------------
 # Required by the Facebook posting utilities to publish on a page.
-FACEBOOK_PAGE_ID = os.getenv("APP_ID", "")
+FACEBOOK_PAGE_ID = os.getenv("FACEBOOK_PAGE_ID", "")
 PAGE_ACCESS_TOKEN = os.getenv("PAGE_ACCESS_TOKEN", "")


### PR DESCRIPTION
## Summary
- Fix Facebook configuration to read `FACEBOOK_PAGE_ID` instead of `APP_ID`
- Align documentation and examples to use `PAGE_ACCESS_TOKEN`

## Testing
- `pytest tests/test_facebook_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4e2bda888832589f40d0edf7ea477