### PR TITLE
Pass module name to setup_logger

### DIFF
--- a/generate_post/generate_facebook_post.py
+++ b/generate_post/generate_facebook_post.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from config.openai_utils import chat_gpt
 from config.log_config import setup_logger
 
-logger = setup_logger()
+logger = setup_logger(__name__)
 
 # Construction du chemin absolu vers le fichier de prompt
 prompt_path = os.path.join(os.path.dirname(__file__), 'prompts', 'facebook.txt')

--- a/generate_post/generate_linkedin_post.py
+++ b/generate_post/generate_linkedin_post.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from config.openai_utils import chat_gpt
 from config.log_config import setup_logger
 
-logger = setup_logger()
+logger = setup_logger(__name__)
 
 # Construction du chemin absolu vers le fichier de prompt
 prompt_path = os.path.join(os.path.dirname(__file__), 'prompts', 'linkedin.txt')

--- a/tests/test_openai_integration.py
+++ b/tests/test_openai_integration.py
@@ -1,12 +1,20 @@
 from config.openai_utils import chat_gpt
 from config.log_config import setup_logger
 
-logger = setup_logger()
+logger = setup_logger(__name__)
 
-question = "Donne-moi un exemple de prompt pour Odoo."
-reponse = chat_gpt(question)
 
-if reponse:
-    logger.info(reponse)
-else:
-    logger.error("Une erreur est survenue lors de l'appel à l'API OpenAI. Consulte le fichier de log.")
+def main():
+    question = "Donne-moi un exemple de prompt pour Odoo."
+    reponse = chat_gpt(question)
+
+    if reponse:
+        logger.info(reponse)
+    else:
+        logger.error(
+            "Une erreur est survenue lors de l'appel à l'API OpenAI. Consulte le fichier de log."
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- pass module name to `setup_logger` in Facebook and LinkedIn post generators
- guard `tests/test_openai_integration.py` with `__main__` entry point to avoid API calls during test discovery

## Testing
- `python generate_post/generate_facebook_post.py`
- `python generate_post/generate_linkedin_post.py`
- `PYTHONPATH=. python tests/test_openai_integration.py`
- `pytest tests/test_openai_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e2b8d2ac832593d837520f092b61