### PR TITLE
Handle image-less group cross-posts properly

### DIFF
--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -52,15 +52,22 @@ class FacebookService:
     @log_execution
     def cross_post_to_groups(
         self, message: str, groups: List[str], image: Union[str, BytesIO, None] = None
-    ) -> None:
-        """Diffuse le message dans les groupes donnés."""
+    ) -> List[str]:
+        """Diffuse le message dans les groupes donnés et retourne les IDs de réponse."""
+        response_ids: List[str] = []
         for group in groups:
-            url = f"https://graph.facebook.com/{group}/photos"
-            data = {"caption": message, "access_token": self.page_token}
-            files, fh = self._prepare_files(image)
+            files = fh = None
+            if image is not None:
+                url = f"https://graph.facebook.com/{group}/photos"
+                data = {"caption": message, "access_token": self.page_token}
+                files, fh = self._prepare_files(image)
+            else:
+                url = f"https://graph.facebook.com/{group}/feed"
+                data = {"message": message, "access_token": self.page_token}
             try:
                 response = requests.post(url, data=data, files=files, timeout=10)
                 response.raise_for_status()
+                response_ids.append(response.json().get("id"))
                 self.logger.info(
                     f"Réponse du groupe {group}: {response.text}"
                 )
@@ -68,7 +75,9 @@ class FacebookService:
                 self.logger.exception(
                     f"Erreur lors de la publication dans le groupe {group} : {e}"
                 )
+                raise
             finally:
                 if fh:
                     fh.close()
+        return response_ids
 


### PR DESCRIPTION
## Summary
- Use /feed endpoint when no image is supplied
- Return response IDs from group cross posts and raise on errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e5af3e10832595c934a0fa7249f9