### PR TITLE
Add Facebook posting endpoint tests and logic

### DIFF
--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -34,9 +34,13 @@ class FacebookService:
         self, message: str, image: Union[str, BytesIO, None] = None
     ) -> None:
         """Planifie un post sur la page Facebook principale."""
-        url = f"https://graph.facebook.com/{self.page_id}/photos"
-        data = {"caption": message, "access_token": self.page_token}
         files, fh = self._prepare_files(image)
+        if files:
+            url = f"https://graph.facebook.com/{self.page_id}/photos"
+            data = {"caption": message, "access_token": self.page_token}
+        else:
+            url = f"https://graph.facebook.com/{self.page_id}/feed"
+            data = {"message": message, "access_token": self.page_token}
         try:
             response = requests.post(url, data=data, files=files, timeout=10)
             response.raise_for_status()
@@ -55,9 +59,13 @@ class FacebookService:
     ) -> None:
         """Diffuse le message dans les groupes donnés."""
         for group in groups:
-            url = f"https://graph.facebook.com/{group}/photos"
-            data = {"caption": message, "access_token": self.page_token}
             files, fh = self._prepare_files(image)
+            if files:
+                url = f"https://graph.facebook.com/{group}/photos"
+                data = {"caption": message, "access_token": self.page_token}
+            else:
+                url = f"https://graph.facebook.com/{group}/feed"
+                data = {"message": message, "access_token": self.page_token}
             try:
                 response = requests.post(url, data=data, files=files, timeout=10)
                 response.raise_for_status()

--- a/tests/test_facebook_service.py
+++ b/tests/test_facebook_service.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch, Mock, mock_open
+import logging
+
+import config
+from services.facebook_service import FacebookService
+
+
+class FacebookServiceTests(unittest.TestCase):
+    @patch.object(config, "FACEBOOK_PAGE_ID", "123")
+    @patch.object(config, "PAGE_ACCESS_TOKEN", "token")
+    @patch("services.facebook_service.requests.post")
+    def test_post_without_image_uses_feed(self, mock_post, *_):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = "ok"
+        mock_post.return_value = mock_response
+
+        service = FacebookService(logger=logging.getLogger("test"))
+        service.post_to_facebook_page("hello world")
+
+        mock_post.assert_called_once_with(
+            "https://graph.facebook.com/123/feed",
+            data={"message": "hello world", "access_token": "token"},
+            files=None,
+            timeout=10,
+        )
+
+    @patch.object(config, "FACEBOOK_PAGE_ID", "123")
+    @patch.object(config, "PAGE_ACCESS_TOKEN", "token")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("services.facebook_service.requests.post")
+    def test_post_with_image_uses_photos_and_closes_file(self, mock_post, mock_file, *_):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = "ok"
+        mock_post.return_value = mock_response
+
+        service = FacebookService(logger=logging.getLogger("test"))
+        service.post_to_facebook_page("hello", "image.jpg")
+
+        file_handle = mock_file.return_value
+        expected_files = {"source": file_handle}
+        mock_post.assert_called_once_with(
+            "https://graph.facebook.com/123/photos",
+            data={"caption": "hello", "access_token": "token"},
+            files=expected_files,
+            timeout=10,
+        )
+        mock_file.assert_called_once_with("image.jpg", "rb")
+        file_handle.close.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Ensure FacebookService uses /feed when no image and /photos when uploading images
- Add tests validating correct endpoint and file handling when posting to Facebook

## Testing
- `pytest -q`
- `pytest tests/test_facebook_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e5afbb7883259f51b507e642265c