### PR TITLE
Log Facebook API errors and add failing API log test

### DIFF
--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -58,10 +58,18 @@ class FacebookService:
             self.logger.info(f"Facebook page response: {response.text}")
             return response.json()
         except Exception as e:
+            response = getattr(e, "response", None)
+            if response is not None:
+                try:
+                    error_detail = response.json()
+                except ValueError:
+                    error_detail = response.text
+            else:
+                error_detail = str(e)
             self.logger.exception(
-                f"Erreur lors de la publication sur la page Facebook : {e}"
+                f"Erreur lors de la publication sur la page Facebook : {error_detail}"
             )
-            return None
+            raise requests.HTTPError(response=response) from e
         finally:
             if fh:
                 fh.close()


### PR DESCRIPTION
## Summary
- log Facebook API error details and re-raise as requests.HTTPError
- adjust facebook page posting tests and add regression test for API errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f95a29488325bbf746e3c8b703c1