### PR TITLE
Refactor Facebook page posting configuration

### DIFF
--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -35,6 +35,7 @@ class FacebookService:
     ) -> dict | None:
         """Planifie un post sur la page Facebook principale."""
         files, fh = self._prepare_files(image)
+
         if files:
             url = f"https://graph.facebook.com/{self.page_id}/photos"
             data = {"caption": message, "access_token": self.page_token}
@@ -42,15 +43,9 @@ class FacebookService:
             url = f"https://graph.facebook.com/{self.page_id}/feed"
             data = {"message": message, "access_token": self.page_token}
 
-
+        request_kwargs = {"data": data, "timeout": 10}
         if files:
-            url = f"https://graph.facebook.com/{self.page_id}/photos"
-            data = {"caption": message, "access_token": self.page_token}
-            request_kwargs = {"data": data, "files": files, "timeout": 10}
-        else:
-            url = f"https://graph.facebook.com/{self.page_id}/feed"
-            data = {"message": message, "access_token": self.page_token}
-            request_kwargs = {"data": data, "timeout": 10}
+            request_kwargs["files"] = files
 
         try:
             response = requests.post(url, **request_kwargs)

--- a/tests/test_facebook_service.py
+++ b/tests/test_facebook_service.py
@@ -1,109 +1,52 @@
-import unittest
-from unittest.mock import patch, Mock, mock_open
 import logging
-import pytest
-from io import BytesIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, mock_open, patch
 
 import config
 from services.facebook_service import FacebookService
 
 
-class FacebookServiceTests(unittest.TestCase):
-    @patch.object(config, "FACEBOOK_PAGE_ID", "123")
-    @patch.object(config, "PAGE_ACCESS_TOKEN", "token")
-    @patch("services.facebook_service.requests.post")
-    def test_post_without_image_uses_feed(self, mock_post, *_):
-        mock_response = Mock()
-        mock_response.raise_for_status = Mock()
-        mock_response.text = "ok"
-        mock_post.return_value = mock_response
-
-        service = FacebookService(logger=logging.getLogger("test"))
-        service.post_to_facebook_page("hello world")
-
-        mock_post.assert_called_once_with(
-            "https://graph.facebook.com/123/feed",
-            data={"message": "hello world", "access_token": "token"},
-            files=None,
-            timeout=10,
-        )
-
-    @patch.object(config, "FACEBOOK_PAGE_ID", "123")
-    @patch.object(config, "PAGE_ACCESS_TOKEN", "token")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("services.facebook_service.requests.post")
-    def test_post_with_image_uses_photos_and_closes_file(self, mock_post, mock_file, *_):
-        mock_response = Mock()
-        mock_response.raise_for_status = Mock()
-        mock_response.text = "ok"
-        mock_post.return_value = mock_response
-
-        service = FacebookService(logger=logging.getLogger("test"))
-        service.post_to_facebook_page("hello", "image.jpg")
-
-        file_handle = mock_file.return_value
-        expected_files = {"source": file_handle}
-        mock_post.assert_called_once_with(
-            "https://graph.facebook.com/123/photos",
-            data={"caption": "hello", "access_token": "token"},
-            files=expected_files,
-            timeout=10,
-        )
-        mock_file.assert_called_once_with("image.jpg", "rb")
-        file_handle.close.assert_called_once()
-
-
-if __name__ == "__main__":
-    unittest.main()
-=======
+@patch.object(config, "FACEBOOK_PAGE_ID", "123")
+@patch.object(config, "PAGE_ACCESS_TOKEN", "token")
 @patch("services.facebook_service.requests.post")
-def test_post_to_page_without_image(mock_post, monkeypatch):
-    monkeypatch.setattr(config, "FACEBOOK_PAGE_ID", "123")
-    monkeypatch.setattr(config, "PAGE_ACCESS_TOKEN", "token")
+def test_post_without_image_uses_feed(mock_post):
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.text = "ok"
+    mock_post.return_value = mock_response
 
-    logger = MagicMock()
-    service = FacebookService(logger)
+    service = FacebookService(logger=logging.getLogger("test"))
+    service.post_to_facebook_page("hello world")
 
-    response = MagicMock()
-    response.raise_for_status = MagicMock()
-    response.text = "ok"
-    response.json.return_value = {"id": "post123"}
-    mock_post.return_value = response
-
-    result = service.post_to_facebook_page("hello world")
-
-    assert result == {"id": "post123"}
-    mock_post.assert_called_once()
-    url = mock_post.call_args[0][0]
+    url = mock_post.call_args.args[0]
     kwargs = mock_post.call_args.kwargs
     assert url == "https://graph.facebook.com/123/feed"
     assert kwargs["data"] == {"message": "hello world", "access_token": "token"}
     assert "files" not in kwargs
+    assert kwargs["timeout"] == 10
 
 
+@patch.object(config, "FACEBOOK_PAGE_ID", "123")
+@patch.object(config, "PAGE_ACCESS_TOKEN", "token")
+@patch("builtins.open", new_callable=mock_open)
 @patch("services.facebook_service.requests.post")
-def test_post_to_page_with_image(mock_post, monkeypatch):
-    monkeypatch.setattr(config, "FACEBOOK_PAGE_ID", "123")
-    monkeypatch.setattr(config, "PAGE_ACCESS_TOKEN", "token")
+def test_post_with_image_uses_photos_and_closes_file(mock_post, mock_file):
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.text = "ok"
+    mock_post.return_value = mock_response
 
-    logger = MagicMock()
-    service = FacebookService(logger)
+    service = FacebookService(logger=logging.getLogger("test"))
+    service.post_to_facebook_page("hello", "image.jpg")
 
-    response = MagicMock()
-    response.raise_for_status = MagicMock()
-    response.text = "ok"
-    response.json.return_value = {"id": "post456"}
-    mock_post.return_value = response
+    file_handle = mock_file.return_value
+    expected_files = {"source": file_handle}
 
-    image = BytesIO(b"image")
-    result = service.post_to_facebook_page("hello", image)
-
-    assert result == {"id": "post456"}
-    mock_post.assert_called_once()
-    url = mock_post.call_args[0][0]
+    url = mock_post.call_args.args[0]
     kwargs = mock_post.call_args.kwargs
     assert url == "https://graph.facebook.com/123/photos"
     assert kwargs["data"] == {"caption": "hello", "access_token": "token"}
-    assert "files" in kwargs
-    assert "source" in kwargs["files"]
+    assert kwargs["files"] == expected_files
+    assert kwargs["timeout"] == 10
+    mock_file.assert_called_once_with("image.jpg", "rb")
+    file_handle.close.assert_called_once()
+


### PR DESCRIPTION
## Summary
- Avoid duplicating URL and payload logic in `post_to_facebook_page`
- Verify expected URL and payload in Facebook posting tests

## Testing
- `pytest tests/test_facebook_service.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f95b18948325839732b1cf787ed9