### PR TITLE
feat: add system prompt to OpenAI posts

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -1,6 +1,7 @@
 import base64
 import os
 from io import BytesIO
+from pathlib import Path
 from typing import List
 
 from openai import OpenAI, OpenAIError
@@ -16,6 +17,9 @@ class OpenAIService:
     def __init__(self, logger) -> None:
         self.logger = logger
         self.client = OpenAI()
+        self.prompt_system = (
+            Path(__file__).resolve().parents[1] / "prompt_system.txt"
+        ).read_text(encoding="utf-8")
 
     @log_execution
     def generate_post_versions(self, text: str) -> List[str]:
@@ -26,9 +30,13 @@ class OpenAIService:
             f"{text}"
         )
         try:
+            messages = [
+                {"role": "system", "content": self.prompt_system},
+                {"role": "user", "content": prompt},
+            ]
             response = self.client.chat.completions.create(
                 model="gpt-4o-mini",
-                messages=[{"role": "user", "content": prompt}],
+                messages=messages,
                 temperature=1.0,
             )
             content = response.choices[0].message.content

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -1,5 +1,6 @@
 import base64
 from io import BytesIO
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import openai
@@ -49,8 +50,10 @@ def test_generate_post_versions(monkeypatch):
 
     assert versions == ["A", "B", "C"]
     assert dummy_client.chat.completions.called_with["temperature"] >= 1.0
-    prompt = dummy_client.chat.completions.called_with["messages"][0]["content"]
-    assert "versions DISTINCTES" in prompt
+    messages = dummy_client.chat.completions.called_with["messages"]
+    expected_prompt = Path("prompt_system.txt").read_text(encoding="utf-8")
+    assert messages[0] == {"role": "system", "content": expected_prompt}
+    assert "versions DISTINCTES" in messages[1]["content"]
 
 @patch("services.openai_service.OpenAI")
 def test_generate_illustrations_returns_bytesio(mock_openai):


### PR DESCRIPTION
## Summary
- load prompt_system.txt when initializing OpenAIService
- send system prompt to OpenAI in generate_post_versions
- test system message presence in OpenAIService

## Testing
- `pytest tests/test_openai_service.py::test_generate_post_versions -q`
- `pytest -q` *(fails: NameError: name 'unittest' is not defined in tests/test_facebook_service.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a56e87d13c83258d50afde6b40a741