### PR TITLE
Add text message handling to TelegramService

### DIFF
--- a/services/telegram_service.py
+++ b/services/telegram_service.py
@@ -31,9 +31,15 @@ class TelegramService:
                 filters.VOICE & filters.User(self.allowed_user_id), self._voice_handler
             )
         )
+        self.app.add_handler(
+            MessageHandler(
+                filters.TEXT & filters.User(self.allowed_user_id), self._text_handler
+            )
+        )
         self.app.add_handler(CallbackQueryHandler(self._callback_handler))
         self.loop: asyncio.AbstractEventLoop | None = None
         self._voice_future: asyncio.Future[str] | None = None
+        self._text_future: asyncio.Future[str] | None = None
         self._callback_future: asyncio.Future[str] | None = None
         self._thread: threading.Thread | None = None
 
@@ -96,6 +102,34 @@ class TelegramService:
         if not self.loop:
             raise RuntimeError("Le bot Telegram n'est pas démarré")
         return asyncio.run_coroutine_threadsafe(self._wait_voice(), self.loop).result()
+
+    # ------------------------------------------------------------------
+    # Gestion des messages texte
+    # ------------------------------------------------------------------
+    async def _text_handler(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        if not (update.message and update.message.text):
+            return
+        if self._text_future is None or self._text_future.done():
+            return
+        self._text_future.set_result(update.message.text)
+
+    async def _wait_text(self) -> str:
+        assert self.loop is not None
+        self._text_future = self.loop.create_future()
+        return await self._text_future
+
+    @log_execution
+    def wait_for_text_message(self) -> str:
+        if not self.loop:
+            raise RuntimeError("Le bot Telegram n'est pas démarré")
+        return asyncio.run_coroutine_threadsafe(self._wait_text(), self.loop).result()
+
+    @log_execution
+    def ask_text(self, prompt: str) -> str:
+        self.send_message(prompt)
+        return self.wait_for_text_message()
 
     # ------------------------------------------------------------------
     # Questions avec boutons

--- a/tests/test_telegram_service.py
+++ b/tests/test_telegram_service.py
@@ -33,3 +33,30 @@ def test_ask_image_returns_selected_image(mock_app):
     assert app.bot.send_photo.await_count == 2
     assert app.bot.send_message.await_count == 1
     loop.close()
+
+
+@patch("services.telegram_service.Application")
+def test_ask_text_returns_user_input(mock_app):
+    builder = MagicMock()
+    builder.token.return_value = builder
+    app = MagicMock()
+    app.add_handler = MagicMock()
+    builder.build.return_value = app
+    mock_app.builder.return_value = builder
+
+    service = TelegramService(MagicMock())
+    service.send_message = MagicMock()
+    loop = asyncio.new_event_loop()
+    service.loop = loop
+
+    async def runner():
+        task = asyncio.create_task(asyncio.to_thread(service.ask_text, "prompt"))
+        while service._text_future is None:
+            await asyncio.sleep(0)
+        service._text_future.set_result("answer")
+        return await task
+
+    result = loop.run_until_complete(runner())
+    assert result == "answer"
+    service.send_message.assert_called_once_with("prompt")
+    loop.close()


### PR DESCRIPTION
## Summary
- add text message handler to TelegramService
- support waiting for and asking text prompts
- test text interactions with TelegramService

## Testing
- `pytest tests/test_telegram_service.py::test_ask_text_returns_user_input -q`
- `pytest tests/test_telegram_service.py::test_ask_image_returns_selected_image -q`


------
https://chatgpt.com/codex/tasks/task_e_68a570d1083483258ab82d76216e16f8