### PR TITLE
feat: apply text correction via OpenAI

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -48,6 +48,46 @@ class OpenAIService:
             return []
 
     @log_execution
+    def apply_corrections(self, text: str, corrections: str) -> str:
+        """Applique une liste de corrections sur un texte.
+
+        Parameters
+        ----------
+        text: str
+            Le texte d'origine.
+        corrections: str
+            Les instructions de correction à appliquer.
+
+        Returns
+        -------
+        str
+            Le texte corrigé. En cas d'erreur, retourne le texte original.
+        """
+
+        prompt = (
+            "Corrige le texte suivant en appliquant les corrections fournies.\n"
+            f"Texte: {text}\n"
+            f"Corrections: {corrections}"
+        )
+
+        try:
+            messages = [
+                {"role": "system", "content": self.prompt_system},
+                {"role": "user", "content": prompt},
+            ]
+            response = self.client.chat.completions.create(
+                model="gpt-4o-mini",
+                messages=messages,
+                temperature=0.0,
+            )
+            return response.choices[0].message.content.strip()
+        except Exception as err:  # pragma: no cover - log then ignore
+            self.logger.exception(
+                f"Erreur lors de l'application des corrections : {err}"
+            )
+            return text
+
+    @log_execution
     def generate_illustrations(self, prompt: str) -> List[BytesIO]:
         """Génère une liste d'illustrations en mémoire.
 

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -98,3 +98,49 @@ def test_generate_illustrations_invalid_request(mock_openai):
     result = service.generate_illustrations("prompt")
 
     assert result == []
+
+
+def test_apply_corrections(monkeypatch):
+    class DummyCompletions:
+        def __init__(self):
+            self.called_with = None
+
+        def create(self, **kwargs):
+            self.called_with = kwargs
+            response = type(
+                "Response",
+                (),
+                {
+                    "choices": [
+                        type(
+                            "Choice",
+                            (),
+                            {
+                                "message": type(
+                                    "Msg", (), {"content": "Texte corrigé"}
+                                )()
+                            },
+                        )()
+                    ]
+                },
+            )
+            return response
+
+    class DummyClient:
+        def __init__(self):
+            self.chat = type("Chat", (), {"completions": DummyCompletions()})()
+
+    dummy_client = DummyClient()
+    monkeypatch.setattr("services.openai_service.OpenAI", lambda: dummy_client)
+    service = OpenAIService(DummyLogger())
+
+    text = "Bonjour le monde"
+    corrections = "Remplacer Bonjour par Salut"
+    result = service.apply_corrections(text, corrections)
+
+    assert result == "Texte corrigé"
+    messages = dummy_client.chat.completions.called_with["messages"]
+    expected_prompt = Path("prompt_system.txt").read_text(encoding="utf-8")
+    assert messages[0] == {"role": "system", "content": expected_prompt}
+    assert text in messages[1]["content"]
+    assert corrections in messages[1]["content"]


### PR DESCRIPTION
## Summary
- add `apply_corrections` to OpenAIService to apply user-provided edits
- test corrections flow and system prompt usage

## Testing
- `pytest tests/test_openai_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a570e9e89c8325be4e39c2d0b67a33