### PR TITLE
Fix Telegram text message handler and test configuration

### DIFF
--- a/services/telegram_service.py
+++ b/services/telegram_service.py
@@ -35,7 +35,6 @@ class TelegramService:
             MessageHandler(
                 filters.TEXT & ~filters.COMMAND & filters.User(self.allowed_user_id),
                 self._text_handler,
-                filters.TEXT & filters.User(self.allowed_user_id), self._text_handler
             )
         )
         self.app.add_handler(CallbackQueryHandler(self._callback_handler))

--- a/tests/test_facebook_service.py
+++ b/tests/test_facebook_service.py
@@ -1,4 +1,5 @@
 import logging
+import unittest
 from unittest.mock import Mock, mock_open, patch
 import pytest
 import requests
@@ -57,6 +58,8 @@ class FacebookServiceTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+@patch.object(config, "FACEBOOK_PAGE_ID", "123")
+@patch.object(config, "PAGE_ACCESS_TOKEN", "token")
 @patch("services.facebook_service.requests.post")
 def test_post_without_image_uses_feed(mock_post):
     mock_response = Mock()


### PR DESCRIPTION
## Summary
- Fix TelegramService text message handler to avoid extra arguments
- Ensure Facebook service tests include missing `unittest` import and configuration patches

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a569e6e7448325b10510b587e8f64d