### PR TITLE
feat: add scheduling option before publishing

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -7,7 +7,7 @@ désormais réalisées via un véritable bot Telegram.
 """
 
 from services.openai_service import OpenAIService
-import asyncio
+from datetime import datetime, timedelta
 from services.telegram_service import TelegramService
 from services.facebook_service import FacebookService
 from config.log_config import setup_logger, log_execution
@@ -60,6 +60,19 @@ def main() -> None:
                         selected_image_path = "selected_image.png"
                         with open(selected_image_path, "wb") as fh:
                             fh.write(chosen_image.getvalue())
+            if telegram_service.ask_yes_no("Souhaitez-vous programmer la publication ?"):
+                now = datetime.utcnow()
+                target = now.replace(hour=20, minute=0, second=0, microsecond=0)
+                if now >= target:
+                    target = (now + timedelta(days=1)).replace(
+                        hour=8, minute=0, second=0, microsecond=0
+                    )
+                facebook_service.schedule_post_to_facebook_page(
+                    choice, target, selected_image_path
+                )
+                telegram_service.send_message("Publication planifiée.")
+                logger.info("Publication programmée avec succès.")
+                continue
 
             facebook_service.post_to_facebook_page(choice, selected_image_path)
             groups = telegram_service.ask_groups()

--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -1,5 +1,6 @@
 from typing import List, Union
 from io import BytesIO
+from datetime import datetime
 
 import config
 import requests
@@ -63,6 +64,60 @@ class FacebookService:
                 error_detail = str(e)
             self.logger.exception(
                 f"Erreur lors de la publication sur la page Facebook : {error_detail}"
+            )
+            raise requests.HTTPError(response=response) from e
+        finally:
+            if fh:
+                fh.close()
+
+    @log_execution
+    def schedule_post_to_facebook_page(
+        self,
+        message: str,
+        publish_time: datetime,
+        image: Union[str, BytesIO, None] = None,
+    ) -> dict | None:
+        """Planifie la publication d'un post sur la page principale."""
+        files, fh = self._prepare_files(image)
+        timestamp = int(publish_time.timestamp())
+
+        if files:
+            url = f"https://graph.facebook.com/{self.page_id}/photos"
+            data = {
+                "caption": message,
+                "published": "false",
+                "scheduled_publish_time": timestamp,
+                "access_token": self.page_token,
+            }
+        else:
+            url = f"https://graph.facebook.com/{self.page_id}/feed"
+            data = {
+                "message": message,
+                "published": "false",
+                "scheduled_publish_time": timestamp,
+                "access_token": self.page_token,
+            }
+
+        request_kwargs = {"data": data, "timeout": 10}
+        if files:
+            request_kwargs["files"] = files
+
+        try:
+            response = requests.post(url, **request_kwargs)
+            response.raise_for_status()
+            self.logger.info(f"Facebook page response: {response.text}")
+            return response.json()
+        except Exception as e:
+            response = getattr(e, "response", None)
+            if response is not None:
+                try:
+                    error_detail = response.json()
+                except ValueError:
+                    error_detail = response.text
+            else:
+                error_detail = str(e)
+            self.logger.exception(
+                f"Erreur lors de la programmation sur la page Facebook : {error_detail}"
             )
             raise requests.HTTPError(response=response) from e
         finally:

--- a/tests/test_audio_post_workflow.py
+++ b/tests/test_audio_post_workflow.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from audio_post_workflow import main as workflow_main
 
 
@@ -52,6 +54,7 @@ class DummyTelegramService:
             "Faut-il corriger cette version ?": True,
             "Ajouter un lien ?": True,
             "Générer des illustrations ?": False,
+            "Souhaitez-vous programmer la publication ?": False,
         }
         return mapping.get(prompt, False)
 
@@ -69,9 +72,13 @@ class DummyFacebookService:
     def __init__(self, logger):
         self.logger = logger
         self.posted = None
+        self.scheduled = None
 
     def post_to_facebook_page(self, text, image_path):
         self.posted = (text, image_path)
+
+    def schedule_post_to_facebook_page(self, text, publish_time, image_path):
+        self.scheduled = (text, publish_time, image_path)
 
     def cross_post_to_groups(self, text, groups, image_path):
         pass
@@ -95,3 +102,39 @@ def test_main_flow(monkeypatch):
     workflow_main()
 
     assert fb_service.posted == ("fixed\nhttp://example.com", None)
+
+
+class SchedulingDummyTelegramService(DummyTelegramService):
+    def ask_yes_no(self, prompt):
+        mapping = {
+            "Faut-il corriger cette version ?": True,
+            "Ajouter un lien ?": True,
+            "Générer des illustrations ?": False,
+            "Souhaitez-vous programmer la publication ?": True,
+        }
+        return mapping.get(prompt, False)
+
+
+def test_scheduling_flow(monkeypatch):
+    monkeypatch.setattr(
+        "audio_post_workflow.setup_logger", lambda name: DummyLogger()
+    )
+    monkeypatch.setattr(
+        "audio_post_workflow.OpenAIService", DummyOpenAIService
+    )
+    monkeypatch.setattr(
+        "audio_post_workflow.TelegramService",
+        SchedulingDummyTelegramService,
+    )
+
+    fb_service = DummyFacebookService(DummyLogger())
+    monkeypatch.setattr(
+        "audio_post_workflow.FacebookService", lambda logger: fb_service
+    )
+
+    workflow_main()
+
+    assert fb_service.scheduled is not None
+    assert fb_service.scheduled[0] == "fixed\nhttp://example.com"
+    assert isinstance(fb_service.scheduled[1], datetime)
+    assert fb_service.posted is None


### PR DESCRIPTION
## Summary
- compute next publish time and schedule via Facebook without Odoo
- expose scheduling helper in Facebook service
- adjust workflow tests to cover scheduled posts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5793ac5848325888b6b1e2a1a0714