### PR TITLE
Align Telegram bot workflow with prompt options

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -37,27 +37,31 @@ def main() -> None:
         try:
             package = openai_service.generate_event_post(text)
             versions = [package.get("standard", ""), package.get("short", "")]
-            choice = telegram_service.ask_options("Choisissez la version", versions)
+            version_choice = telegram_service.ask_options(
+                "Choisissez la version", versions
+            )
             hooks = package.get("hooks", [])
-            hashtags = package.get("hashtags", [])
+            hook_choice = ""
             if hooks:
-                telegram_service.send_message(
-                    "Accroches alternatives:\n" + "\n".join(f"- {h}" for h in hooks)
+                hook_choice = telegram_service.ask_options(
+                    "Choisissez l'accroche", hooks
                 )
+            hashtags = package.get("hashtags", [])
+            hashtag_choices = []
             if hashtags:
-                telegram_service.send_message(
-                    "Hashtags proposés: " + " ".join(hashtags)
+                hashtag_choices = telegram_service.ask_list(
+                    "Choisissez un hashtag", hashtags
                 )
-
-            if telegram_service.ask_yes_no("Faut-il corriger cette version ?"):
-                corrections = telegram_service.ask_text("Envoyez les corrections :")
-                choice = openai_service.apply_corrections(choice, corrections)
-                telegram_service.send_message(choice)
+            choice = hook_choice
+            if choice:
+                choice += "\n\n"
+            choice += version_choice
+            if hashtag_choices:
+                choice += "\n\n" + " ".join(hashtag_choices)
 
             if telegram_service.ask_yes_no("Ajouter un lien ?"):
                 link = telegram_service.ask_text("Quel lien ajouter ?")
                 choice = f"{choice}\n{link}"
-                telegram_service.send_message(choice)
 
             selected_image_path: str | None = None
             if telegram_service.ask_yes_no("Générer des illustrations ?"):
@@ -71,6 +75,14 @@ def main() -> None:
                         selected_image_path = "selected_image.png"
                         with open(selected_image_path, "wb") as fh:
                             fh.write(chosen_image.getvalue())
+
+            telegram_service.send_message(choice)
+
+            if telegram_service.ask_yes_no("Faut-il corriger ce post ?"):
+                corrections = telegram_service.ask_text("Envoyez les corrections :")
+                choice = openai_service.apply_corrections(choice, corrections)
+                telegram_service.send_message(choice)
+
             if telegram_service.ask_yes_no("Souhaitez-vous programmer la publication ?"):
                 now = datetime.utcnow()
                 target = now.replace(hour=20, minute=0, second=0, microsecond=0)

--- a/services/telegram_service.py
+++ b/services/telegram_service.py
@@ -197,6 +197,21 @@ class TelegramService:
             groups.append(choice)
         return groups
 
+    @log_execution
+    def ask_list(self, prompt: str, options: List[str]) -> List[str]:
+        """Permet de sélectionner plusieurs éléments dans ``options``."""
+        selected: List[str] = []
+        available = list(options)
+        while available:
+            choice = self.ask_options(
+                f"{prompt} ou Terminer", available + ["Terminer"]
+            )
+            if choice == "Terminer":
+                break
+            selected.append(choice)
+            available.remove(choice)
+        return selected
+
     async def _ask_images(self, prompt: str, images: List[BytesIO]) -> BytesIO:
         """Affiche des images avec un bouton de choix et renvoie l'image choisie."""
         assert self.loop is not None

--- a/tests/test_telegram_service.py
+++ b/tests/test_telegram_service.py
@@ -36,6 +36,22 @@ def test_ask_image_returns_selected_image(mock_app):
 
 
 @patch("services.telegram_service.Application")
+def test_ask_list_collects_choices(mock_app):
+    builder = MagicMock()
+    builder.token.return_value = builder
+    app = MagicMock()
+    builder.build.return_value = app
+    mock_app.builder.return_value = builder
+
+    service = TelegramService(MagicMock())
+    service.ask_options = MagicMock(side_effect=["a", "b", "Terminer"])
+
+    result = service.ask_list("prompt", ["a", "b", "c"])
+    assert result == ["a", "b"]
+    assert service.ask_options.call_count == 3
+
+
+@patch("services.telegram_service.Application")
 def test_ask_text_returns_user_input(mock_app):
     builder = MagicMock()
     builder.token.return_value = builder


### PR DESCRIPTION
## Summary
- Extend TelegramService with `ask_list` to select multiple items
- Update audio-driven workflow to pick hook, hashtags, and apply corrections last
- Cover new interactions with additional unit tests

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68a5ac1328088325a843e28258f04dfb