### PR TITLE
Sanitize OpenAI outputs for cleaner Telegram posts

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import re
 from io import BytesIO
 from pathlib import Path
 from typing import Dict, List
@@ -21,6 +22,24 @@ class OpenAIService:
         self.prompt_system = (
             Path(__file__).resolve().parents[1] / "prompt_system.txt"
         ).read_text(encoding="utf-8")
+        self.prompt_correction = (
+            "Tu es correcteur·rice pour des posts de réseaux sociaux. "
+            "Corrige le texte fourni selon les instructions et réponds "
+            "uniquement avec le texte final, sans autre commentaire."
+        )
+
+    @staticmethod
+    def _sanitize_text(text: str) -> str:
+        """Nettoie les éléments de mise en forme indésirables."""
+        cleaned = text.replace("*", "")
+        cleaned = re.sub(
+            r"(?i)voici le texte corrigé selon vos indications\s*:?", "", cleaned
+        )
+        cleaned = re.sub(r"(?i)version\s+(standard|courte)\s*:?", "", cleaned)
+        cleaned = re.sub(r"\b\d+\.\s*(#)", r"\1", cleaned)
+        cleaned = re.sub(r"^\s*\d+[\.)]\s*", "", cleaned, flags=re.MULTILINE)
+        cleaned = re.sub(r"\n{2,}", "\n", cleaned)
+        return cleaned.strip()
 
     @log_execution
     def generate_event_post(self, text: str) -> Dict[str, object]:
@@ -87,6 +106,23 @@ class OpenAIService:
                         sections[current].append(line.lstrip("- "))
                 elif current in {"standard", "short", "thanks"} and line:
                     sections[current] += (" " + line)
+        sections["standard"] = self._sanitize_text(sections["standard"])
+        sections["short"] = self._sanitize_text(sections["short"])
+        sections["hooks"] = [self._sanitize_text(h) for h in sections["hooks"]]
+        sanitized_tags = [self._sanitize_text(h) for h in sections["hashtags"]]
+        flat_tags: List[str] = []
+        for part in sanitized_tags:
+            flat_tags.extend(part.split())
+        seen = set()
+        unique_tags: List[str] = []
+        for tag in flat_tags:
+            if not tag.startswith("#"):
+                continue
+            if tag not in seen:
+                unique_tags.append(tag)
+                seen.add(tag)
+        sections["hashtags"] = unique_tags
+        sections["thanks"] = self._sanitize_text(sections["thanks"])
         return sections
 
     @log_execution
@@ -111,17 +147,18 @@ class OpenAIService:
             f"Texte: {text}\n"
             f"Corrections: {corrections}"
         )
-        
+
         try:
             messages = [
-                {"role": "system", "content": self.prompt_system},
+                {"role": "system", "content": self.prompt_correction},
                 {"role": "user", "content": prompt},
             ]
             response = self.client.chat.completions.create(
                 model="gpt-4o-mini",
                 messages=messages,
             )
-            return response.choices[0].message.content.strip()
+            content = response.choices[0].message.content.strip()
+            return self._sanitize_text(content)
         except Exception as err:  # pragma: no cover - log then ignore
             self.logger.exception(
                 f"Erreur lors de l'application des corrections : {err}"

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -16,7 +16,11 @@ class DummyCompletions:
     def __init__(self, content=None):
         self.called_with = None
         self.content = content or (
-            "A) standard\nB) short\nC) accroche1\naccroche2\naccroche3\nD) #tag1 #tag2\nE) merci"
+            "A) Version standard : **Texte standard**\n"
+            "B) Version courte : **Texte court**\n"
+            "C) 1. *accroche1*\n2. accroche2\n3. accroche3\n"
+            "D) #tag1 #tag2\n1. #tag1\n2. #tag2\n"
+            "E) merci"
         )
 
     def create(self, **kwargs):
@@ -51,10 +55,10 @@ def test_generate_event_post(monkeypatch):
 
     result = service.generate_event_post("Mon programme")
 
-    assert result["standard"] == "standard"
-    assert result["short"] == "short"
+    assert result["standard"] == "Texte standard"
+    assert result["short"] == "Texte court"
     assert result["hooks"] == ["accroche1", "accroche2", "accroche3"]
-    assert result["hashtags"] in [["#tag1 #tag2"], ["#tag1", "#tag2"]]
+    assert result["hashtags"] == ["#tag1", "#tag2"]
     messages = dummy_client.chat.completions.called_with["messages"]
     expected_prompt = Path("prompt_system.txt").read_text(encoding="utf-8")
     assert messages[0] == {"role": "system", "content": expected_prompt}
@@ -62,13 +66,17 @@ def test_generate_event_post(monkeypatch):
 
 
 def test_apply_corrections(monkeypatch):
-    dummy_client = DummyClient(content="Texte corrigé")
+    raw = (
+        "Voici le texte corrigé selon vos indications :\n\n"
+        "**Texte corrigé**\n\n1. #tag1\n2. #tag2"
+    )
+    dummy_client = DummyClient(content=raw)
     monkeypatch.setattr("services.openai_service.OpenAI", lambda: dummy_client)
     service = OpenAIService(DummyLogger())
 
     result = service.apply_corrections("Original", "Correction")
 
-    assert result == "Texte corrigé"
+    assert result == "Texte corrigé\n#tag1\n#tag2"
     messages = dummy_client.chat.completions.called_with["messages"]
     assert "Correction" in messages[1]["content"]
 


### PR DESCRIPTION
## Summary
- strip leading numeric prefixes from generated text to avoid enumerated hooks
- split and deduplicate hashtags after sanitization to prevent duplicates
- extend tests with numbered hooks and duplicate hashtags cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b8fb7b348325b5839dc13f1c2af1