### PR TITLE
Refine Telegram post formatting

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -25,7 +25,9 @@ class OpenAIService:
         self.prompt_correction = (
             "Tu es correcteur·rice pour des posts de réseaux sociaux. "
             "Corrige le texte fourni selon les instructions et réponds "
-            "uniquement avec le texte final, sans autre commentaire."
+            "uniquement avec le texte final, sans astérisques, sans préambule "
+            "ni mention de version, et sans commentaire supplémentaire. "
+            "Fournis simplement le texte terminé suivi des hashtags sur une seule ligne."
         )
 
     @staticmethod
@@ -36,9 +38,22 @@ class OpenAIService:
             r"(?i)voici le texte corrigé selon vos indications\s*:?", "", cleaned
         )
         cleaned = re.sub(r"(?i)version\s+(standard|courte)\s*:?", "", cleaned)
+        cleaned = re.sub(r"(?mi)^\s*[-–]{3,}\s*$", "", cleaned)
         cleaned = re.sub(r"\b\d+\.\s*(#)", r"\1", cleaned)
+        cleaned = re.sub(r"(?mi)^\s*\d+\s*hashtags?\s+propos[ée]s?.*$", "", cleaned)
+        cleaned = re.sub(r"(?mi)^si vous avez besoin.*$", "", cleaned)
         cleaned = re.sub(r"\n{2,}", "\n", cleaned)
-        return cleaned.strip()
+        lines = [line.strip() for line in cleaned.splitlines() if line.strip()]
+        hashtags: List[str] = []
+        new_lines: List[str] = []
+        for line in lines:
+            if line.startswith("#"):
+                hashtags.extend(part for part in line.split() if part.startswith("#"))
+            else:
+                new_lines.append(line)
+        if hashtags:
+            new_lines.append(" ".join(dict.fromkeys(hashtags)))
+        return "\n".join(new_lines).strip()
 
     @log_execution
     def generate_event_post(self, text: str) -> Dict[str, object]:

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -68,7 +68,14 @@ def test_generate_event_post(monkeypatch):
 def test_apply_corrections(monkeypatch):
     raw = (
         "Voici le texte corrigé selon vos indications :\n\n"
-        "**Texte corrigé**\n\n1. #tag1\n2. #tag2"
+        "---\n"
+        "**Texte corrigé**\n"
+        "#tag1\n"
+        "#tag2\n"
+        "5 hashtags proposés\n"
+        "1. #tag1\n"
+        "2. #tag2\n"
+        "Si vous avez besoin d'autres informations, n'hésitez pas à demander !"
     )
     dummy_client = DummyClient(content=raw)
     monkeypatch.setattr("services.openai_service.OpenAI", lambda: dummy_client)
@@ -76,7 +83,7 @@ def test_apply_corrections(monkeypatch):
 
     result = service.apply_corrections("Original", "Correction")
 
-    assert result == "Texte corrigé\n#tag1\n#tag2"
+    assert result == "Texte corrigé\n#tag1 #tag2"
     messages = dummy_client.chat.completions.called_with["messages"]
     assert "Correction" in messages[1]["content"]
 


### PR DESCRIPTION
## Summary
- tighten correction prompt to avoid preambles and version labels
- strip dashes, notes, and numbered hashtags from OpenAI output and collapse hashtags into one line
- adjust tests for new sanitization rules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5bdd26c44832597284eec5814e181