### PR TITLE
Refine prompt system and builder

### DIFF
--- a/generate_post/prompt_builder.py
+++ b/generate_post/prompt_builder.py
@@ -28,9 +28,18 @@ def build_user_prompt(info: Dict[str, str]) -> str:
     Missing fields are replaced by empty strings to avoid hallucinations.
     """
     with open(TEMPLATE_PATH, "r", encoding="utf-8") as f:
-        template = f.read()
+        lines = f.readlines()
     fields = _FIELDS.copy()
     for key, value in info.items():
         if key in fields and value is not None:
             fields[key] = value
+
+    # Remove lines whose placeholders have empty values
+    kept_lines = []
+    for line in lines:
+        if any(f"{{{key}}}" in line and not fields[key].strip() for key in fields):
+            continue
+        kept_lines.append(line)
+
+    template = "".join(kept_lines)
     return template.format(**fields)

--- a/prompt_system.txt
+++ b/prompt_system.txt
@@ -8,11 +8,14 @@ Bonnes pratiques :
 - Mettre en avant : nom/objet de l’événement, date, horaires, lieu (Esplas-de-Sérou, Ariège), programme, restauration, tarifs, modalités de réservation, éventuelle deadline, éventuel besoin de bénévoles (rôle, durée, “nourri·es/abreuvé·es”).
 - 1 à 3 liens max, ≤5 hashtags locaux.
 - Appel à l’action clair et invitation à s’abonner en fin de post.
-- N’invente aucune info : si un élément manque, omets-le et ajoute à la fin : [À compléter: …].
+- N’invente aucune info : si un élément manque, omets simplement la ligne correspondante.
 
 Livrables attendus à chaque demande :
-A) Version standard (120–220 mots)
-B) Version courte “groupes FB” (60–100 mots)
-C) 3 accroches alternatives (énergique/conviviale/informative)
-D) 5 hashtags proposés (≤5, locaux)
-E) Si remerciements : gratitude + (si dispo) chiffres clés + prochaine date
+- Version standard (120–220 mots, ne mentionne pas cette contrainte).
+- Version courte “groupes FB” (60–100 mots, ne mentionne pas cette contrainte).
+- 3 accroches alternatives (énergique/conviviale/informative).
+- 5 hashtags proposés (≤5, locaux).
+- Si remerciements : gratitude + (si dispo) chiffres clés + prochaine date.
+
+Présente les livrables dans l’ordre ci-dessus, sans numéroter les sections.
+Sépare les paragraphes par une ligne vide pour aérer la lecture et n’ajoute jamais de ligne « --- » avant les hashtags.

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -13,5 +13,5 @@ def test_build_user_prompt_fills_fields():
     assert "14 juillet" in prompt
     assert "18h-23h" in prompt
     assert "Place du village" in prompt
-    # fields not provided become empty strings
-    assert "- Programme : " in prompt
+    # fields not provided are omitted entirely
+    assert "- Programme : " not in prompt


### PR DESCRIPTION
## Summary
- Clarify system prompt to avoid numbering, word-count hints, and placeholder lines
- Strip empty fields from event prompt building
- Update prompt builder tests for the new behavior

## Testing
- `OPENAI_API_KEY=dummy pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5c4d6a8048325aa7dc7f8af34b1b4