### PR TITLE
Handle new OpenAI event post format

### DIFF
--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -16,11 +16,11 @@ class DummyCompletions:
     def __init__(self, content=None):
         self.called_with = None
         self.content = content or (
-            "A) Version standard : **Texte standard**\n"
-            "B) Version courte : **Texte court**\n"
-            "C) accroche1\naccroche2\naccroche3\n"
-            "D) 1. #tag1\n2. #tag2\n"
-            "E) merci"
+            "Version standard:\nTexte standard\n\n"
+            "Version courte:\nTexte court\n\n"
+            "Accroches:\n- accroche1\n- accroche2\n- accroche3\n\n"
+            "Hashtags:\n#tag1 #tag2\n\n"
+            "Remerciements:\nmerci"
         )
 
     def create(self, **kwargs):


### PR DESCRIPTION
## Summary
- Adapt OpenAI event post parsing to the new heading-based format
- Update unit test for revised OpenAI response structure

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5c717ca1083259dc272fd04ae52f2