### PR TITLE
Simplify prompt workflow

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -35,29 +35,7 @@ def main() -> None:
             break
 
         try:
-            package = openai_service.generate_event_post(text)
-            versions = [package.get("standard", ""), package.get("short", "")]
-            version_choice = telegram_service.ask_options(
-                "Choisissez la version", versions
-            )
-            hooks = package.get("hooks", [])
-            hook_choice = ""
-            if hooks:
-                hook_choice = telegram_service.ask_options(
-                    "Choisissez l'accroche", hooks
-                )
-            hashtags = package.get("hashtags", [])
-            hashtag_choices = []
-            if hashtags:
-                hashtag_choices = telegram_service.ask_list(
-                    "Choisissez un hashtag", hashtags
-                )
-            choice = hook_choice
-            if choice:
-                choice += "\n\n"
-            choice += version_choice
-            if hashtag_choices:
-                choice += "\n\n" + " ".join(hashtag_choices)
+            choice = openai_service.generate_event_post(text)
 
             if telegram_service.ask_yes_no("Ajouter un lien ?"):
                 link = telegram_service.ask_text("Quel lien ajouter ?")

--- a/generate_post/prompts/event_template.txt
+++ b/generate_post/prompts/event_template.txt
@@ -1,5 +1,4 @@
-Génère les livrables A–E selon les règles système ci-dessus.
-Infos connues (copie-colle brut ci-dessous ; n’ajoute rien qui n’y figure pas) :
+Rédige un post pour les réseaux sociaux à partir des informations ci-dessous. N'invente rien si une donnée manque.
 
 - Objet/nom : {objet}
 - Date : {date}

--- a/prompt_system.txt
+++ b/prompt_system.txt
@@ -1,21 +1,3 @@
 Tu es le(la) rédacteur·rice social media du Comité des Fêtes d’Esplas-de-Sérou (Ariège).
-Écrire en français, ton chaleureux, local, inclusif. Parler à la 1ʳᵉ personne du pluriel (“nous”, “on”), jamais “je”.
+Écrire en français, ton chaleureux, local, inclusif. Parler à la 1ʳᵉ personne du pluriel (“nous”, “on”), jamais “je”. Utiliser des emojis.
 Objectifs des posts : (1) clarté immédiate (quoi/quand/où/prix), (2) conversion (réserver, s’inscrire, envoyer un message, partager), (3) engagement (commentaires, abonnements).
-
-Bonnes pratiques :
-- Accroche courte et vivante en ouverture (proposer 3 variantes).
-- Corps en puces avec emojis sobres (📍🕒🍽️🎶🍻🧑‍🤝‍🧑).
-- Mettre en avant : nom/objet de l’événement, date, horaires, lieu (Esplas-de-Sérou, Ariège), programme, restauration, tarifs, modalités de réservation, éventuelle deadline, éventuel besoin de bénévoles (rôle, durée, “nourri·es/abreuvé·es”).
-- 1 à 3 liens max, ≤5 hashtags locaux.
-- Appel à l’action clair et invitation à s’abonner en fin de post.
-- N’invente aucune info : si un élément manque, omets simplement la ligne correspondante.
-
-Livrables attendus à chaque demande :
-- Version standard (120–220 mots, ne mentionne pas cette contrainte).
-- Version courte “groupes FB” (60–100 mots, ne mentionne pas cette contrainte).
-- 3 accroches alternatives (énergique/conviviale/informative).
-- 5 hashtags proposés (≤5, locaux).
-- Si remerciements : gratitude + (si dispo) chiffres clés + prochaine date.
-
-Présente les livrables dans l’ordre ci-dessus, sans numéroter les sections.
-Sépare les paragraphes par une ligne vide pour aérer la lecture et n’ajoute jamais de ligne « --- » avant les hashtags.

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -1,5 +1,7 @@
 import base64
 from io import BytesIO
+import base64
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -15,13 +17,7 @@ class DummyLogger:
 class DummyCompletions:
     def __init__(self, content=None):
         self.called_with = None
-        self.content = content or (
-            "Version standard:\nTexte standard\n\n"
-            "Version courte:\nTexte court\n\n"
-            "Accroches:\n- accroche1\n- accroche2\n- accroche3\n\n"
-            "Hashtags:\n#tag1 #tag2\n\n"
-            "Remerciements:\nmerci"
-        )
+        self.content = content or "Texte final"
 
     def create(self, **kwargs):
         self.called_with = kwargs
@@ -55,10 +51,7 @@ def test_generate_event_post(monkeypatch):
 
     result = service.generate_event_post("Mon programme")
 
-    assert result["standard"] == "Texte standard"
-    assert result["short"] == "Texte court"
-    assert result["hooks"] == ["accroche1", "accroche2", "accroche3"]
-    assert result["hashtags"] == ["#tag1", "#tag2"]
+    assert result == "Texte final"
     messages = dummy_client.chat.completions.called_with["messages"]
     expected_prompt = Path("prompt_system.txt").read_text(encoding="utf-8")
     assert messages[0] == {"role": "system", "content": expected_prompt}


### PR DESCRIPTION
## Summary
- streamline Telegram audio workflow to produce a single post without version, hook or hashtag selection
- replace system and user prompts with simplified guidelines
- adjust OpenAI service and tests for new single-text output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6b4f29a188325a680cefaa572c26b