### PR TITLE
feat: handle telegram commands for post workflow

### DIFF
--- a/services/telegram_service.py
+++ b/services/telegram_service.py
@@ -31,9 +31,11 @@ class TelegramService:
                 filters.VOICE & filters.User(self.allowed_user_id), self._voice_handler
             )
         )
+        # Les commandes (préfixées par /) sont traitées comme du texte afin de
+        # permettre la gestion personnalisée dans le workflow principal.
         self.app.add_handler(
             MessageHandler(
-                filters.TEXT & ~filters.COMMAND & filters.User(self.allowed_user_id),
+                filters.TEXT & filters.User(self.allowed_user_id),
                 self._text_handler,
             )
         )

--- a/tests/test_audio_post_workflow.py
+++ b/tests/test_audio_post_workflow.py
@@ -26,7 +26,8 @@ class DummyTelegramService:
     def __init__(self, logger, openai_service):
         self.logger = logger
         self.openai_service = openai_service
-        self._voice_step = 0
+        self.messages = ["transcribed", "/publier", ""]
+        self.index = 0
 
     def start(self):
         pass
@@ -35,20 +36,9 @@ class DummyTelegramService:
         pass
 
     def wait_for_message(self):
-        if self._voice_step == 0:
-            self._voice_step += 1
-            return "transcribed"
-        return ""
-
-    def ask_yes_no(self, prompt):
-        mapping = {
-            "Générer des illustrations ?": False,
-            "Souhaitez-vous programmer la publication ?": False,
-        }
-        return mapping.get(prompt, False)
-
-    def ask_image(self, prompt, illustrations):
-        return None
+        msg = self.messages[self.index]
+        self.index += 1
+        return msg
 
     def ask_groups(self):
         return []
@@ -91,12 +81,9 @@ def test_main_flow(monkeypatch):
 
 
 class SchedulingDummyTelegramService(DummyTelegramService):
-    def ask_yes_no(self, prompt):
-        mapping = {
-            "Générer des illustrations ?": False,
-            "Souhaitez-vous programmer la publication ?": True,
-        }
-        return mapping.get(prompt, False)
+    def __init__(self, logger, openai_service):
+        super().__init__(logger, openai_service)
+        self.messages = ["transcribed", "/programmer", ""]
 
 
 def test_scheduling_flow(monkeypatch):


### PR DESCRIPTION
## Summary
- allow telegram service to treat slash commands as regular text
- rework audio workflow to handle /illustrer, /publier, and /programmer commands
- update tests for command-based post publishing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6c138d8048325a219f5d476368275