### PR TITLE
Simplify event post generation

### DIFF
--- a/generate_post/prompts/event_template.txt
+++ b/generate_post/prompts/event_template.txt
@@ -1,4 +1,4 @@
-Rédige un post pour les réseaux sociaux à partir des informations ci-dessous. N'invente rien si une donnée manque.
+Rédige un post pour les réseaux sociaux à partir des informations ci-dessous.
 
 - Objet/nom : {objet}
 - Date : {date}

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -1,7 +1,5 @@
 import base64
 from io import BytesIO
-import base64
-from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -59,24 +57,13 @@ def test_generate_event_post(monkeypatch):
 
 
 def test_apply_corrections(monkeypatch):
-    raw = (
-        "Voici le texte corrigé selon vos indications :\n\n"
-        "---\n"
-        "**Texte corrigé**\n"
-        "#tag1\n"
-        "#tag2\n"
-        "5 hashtags proposés\n"
-        "1. #tag1\n"
-        "2. #tag2\n"
-        "Si vous avez besoin d'autres informations, n'hésitez pas à demander !"
-    )
+    raw = "Texte corrigé"
     dummy_client = DummyClient(content=raw)
     monkeypatch.setattr("services.openai_service.OpenAI", lambda: dummy_client)
     service = OpenAIService(DummyLogger())
 
     result = service.apply_corrections("Original", "Correction")
-
-    assert result == "Texte corrigé\n#tag1 #tag2"
+    assert result == raw
     messages = dummy_client.chat.completions.called_with["messages"]
     assert "Correction" in messages[1]["content"]
 


### PR DESCRIPTION
## Summary
- Drop request/format cleanup and rely on GPT for final wording
- Pass raw event text to prompt builder and return OpenAI content as-is
- Trim prompt template to a minimal field list

## Testing
- `pytest tests/test_openai_service.py tests/test_audio_post_workflow.py tests/test_prompt_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6c396b74483259598ae3339985a20