### PR TITLE
feat: constrain illustration text

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -3,6 +3,7 @@ import os
 from io import BytesIO
 from pathlib import Path
 from typing import List
+from datetime import datetime
 
 from openai import OpenAI, OpenAIError
 from config.log_config import log_execution
@@ -90,12 +91,25 @@ class OpenAIService:
             return text
 
     @log_execution
-    def generate_illustrations(self, prompt: str) -> List[BytesIO]:
+    def generate_illustrations(
+        self, post: str, event_date: str | None = None
+    ) -> List[BytesIO]:
         """Génère une liste d'illustrations en mémoire.
+
+        L'illustration doit mettre en scène la publication tout en affichant
+        uniquement le texte ``Esplas-de-Sérou <date>`` où ``<date>`` est la date
+        fournie ou, à défaut, la date courante.
 
         Les images renvoyées par l'API sont décodées depuis du base64 et
         converties en ``BytesIO`` afin d'éviter toute écriture sur disque.
         """
+
+        date_str = event_date or datetime.utcnow().strftime("%d/%m/%Y")
+        prompt = (
+            "Crée une illustration représentant la publication suivante : "
+            f"{post}. L'image doit contenir uniquement le texte \"Esplas-de-Sérou "
+            f"{date_str}\" et ne contenir aucun autre texte."
+        )
 
         try:
             response = self.client.images.generate(

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -84,9 +84,11 @@ def test_generate_illustrations_returns_bytesio(mock_openai):
     )()
 
     service = OpenAIService(MagicMock())
-    images = service.generate_illustrations("prompt")
+    images = service.generate_illustrations("prompt", event_date="01/02/2025")
     assert len(images) == 2
     assert all(isinstance(img, BytesIO) for img in images)
+    _, kwargs = mock_client.images.generate.call_args
+    assert "Esplas-de-Sérou 01/02/2025" in kwargs["prompt"]
 
 
 @patch("services.openai_service.OpenAI")


### PR DESCRIPTION
## Summary
- ensure illustration prompt includes only location and date text
- test illustration prompt contains `Esplas-de-Sérou` and the provided date

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a70fd8b43083259ff1b37f7a4d9f76