### PR TITLE
feat: choose style before illustration

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -42,7 +42,26 @@ def main() -> None:
                 if not last_post:
                     telegram_service.send_message("Aucun post à illustrer.")
                     continue
-                illustrations = openai_service.generate_illustrations(last_post)
+                styles = [
+                    "Réaliste",
+                    "Dessin animé",
+                    "Pixel art",
+                    "Manga",
+                    "Aquarelle",
+                    "Croquis",
+                    "Peinture à l'huile",
+                    "Low poly",
+                    "Cyberpunk",
+                    "Art déco",
+                    "Noir et blanc",
+                    "Fantaisie",
+                ]
+                style = telegram_service.ask_options(
+                    "Choisissez un style d'illustration", styles
+                )
+                illustrations = openai_service.generate_illustrations(
+                    last_post, style
+                )
                 if illustrations:
                     chosen_image = telegram_service.ask_image(
                         "Choisissez une illustration", illustrations

--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -92,9 +92,9 @@ class OpenAIService:
 
     @log_execution
     def generate_illustrations(
-        self, post: str, event_date: str | None = None
+        self, post: str, style: str, event_date: str | None = None
     ) -> List[BytesIO]:
-        """Génère une liste d'illustrations en mémoire.
+        """Génère une liste d'illustrations en mémoire dans un style donné.
 
         L'illustration doit mettre en scène la publication tout en affichant
         uniquement le texte ``Esplas-de-Sérou <date>`` où ``<date>`` est la date
@@ -106,9 +106,9 @@ class OpenAIService:
 
         date_str = event_date or datetime.utcnow().strftime("%d/%m/%Y")
         prompt = (
-            "Crée une illustration représentant la publication suivante : "
-            f"{post}. L'image doit contenir uniquement le texte \"Esplas-de-Sérou "
-            f"{date_str}\" et ne contenir aucun autre texte."
+            f"Crée une illustration dans un style {style} représentant la "
+            f"publication suivante : {post}. L'image doit contenir uniquement le "
+            f"texte \"Esplas-de-Sérou {date_str}\" et ne contenir aucun autre texte."
         )
 
         try:

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -84,11 +84,14 @@ def test_generate_illustrations_returns_bytesio(mock_openai):
     )()
 
     service = OpenAIService(MagicMock())
-    images = service.generate_illustrations("prompt", event_date="01/02/2025")
+    images = service.generate_illustrations(
+        "prompt", "Cubisme", event_date="01/02/2025"
+    )
     assert len(images) == 2
     assert all(isinstance(img, BytesIO) for img in images)
     _, kwargs = mock_client.images.generate.call_args
     assert "Esplas-de-Sérou 01/02/2025" in kwargs["prompt"]
+    assert "Cubisme" in kwargs["prompt"]
 
 
 @patch("services.openai_service.OpenAI")
@@ -98,7 +101,7 @@ def test_generate_illustrations_invalid_request(mock_openai):
     mock_client.images.generate.side_effect = openai.OpenAIError("bad request")
 
     service = OpenAIService(MagicMock())
-    result = service.generate_illustrations("prompt")
+    result = service.generate_illustrations("prompt", "Cubisme")
 
     assert result == []
 


### PR DESCRIPTION
## Summary
- allow style selection when requesting illustrations via Telegram
- support style parameter in OpenAI illustration generation
- expand available illustration styles and test coverage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a71abda7cc832596950760e25ba3eb