### PR TITLE
Replace slash commands with inline buttons

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -29,103 +29,91 @@ def main() -> None:
 
     telegram_service.send_message("Il est temps de publier Kevin")
 
-    last_post: str | None = None
-    selected_image_path: str | None = None
-
     while True:
         text = telegram_service.wait_for_message()
         if not text:
             break
 
         try:
-            if text.startswith("/illustrer"):
-                if not last_post:
-                    telegram_service.send_message("Aucun post à illustrer.")
-                    continue
-                styles = [
-                    "Réaliste",
-                    "Dessin animé",
-                    "Pixel art",
-                    "Manga",
-                    "Aquarelle",
-                    "Croquis",
-                    "Peinture à l'huile",
-                    "Low poly",
-                    "Cyberpunk",
-                    "Art déco",
-                    "Noir et blanc",
-                    "Fantaisie",
-                ]
-                style = telegram_service.ask_options(
-                    "Choisissez un style d'illustration", styles
-                )
-                illustrations = openai_service.generate_illustrations(
-                    last_post, style
-                )
-                if illustrations:
-                    chosen_image = telegram_service.ask_image(
-                        "Choisissez une illustration", illustrations
-                    )
-                    if chosen_image:
-                        chosen_image.seek(0)
-                        selected_image_path = "selected_image.png"
-                        with open(selected_image_path, "wb") as fh:
-                            fh.write(chosen_image.getvalue())
-                continue
-
-            if text.startswith("/modifier"):
-                if not last_post:
-                    telegram_service.send_message("Aucun post à modifier.")
-                    continue
-                corrections = telegram_service.ask_text(
-                    "Partagez vos modifications s'il vous plaît !"
-                )
-                last_post = openai_service.apply_corrections(
-                    last_post, corrections
-                )
-                telegram_service.send_message(last_post)
-                continue
-
-            if text.startswith("/publier"):
-                if not last_post:
-                    telegram_service.send_message("Aucun post à publier.")
-                    continue
-                facebook_service.post_to_facebook_page(
-                    last_post, selected_image_path
-                )
-                groups = telegram_service.ask_groups()
-                if groups:
-                    facebook_service.cross_post_to_groups(
-                        last_post, groups, selected_image_path
-                    )
-                telegram_service.send_message("Publication effectuée.")
-                last_post = None
-                selected_image_path = None
-                continue
-
-            if text.startswith("/programmer"):
-                if not last_post:
-                    telegram_service.send_message("Aucun post à programmer.")
-                    continue
-                now = datetime.utcnow()
-                target = now.replace(hour=20, minute=0, second=0, microsecond=0)
-                if now >= target:
-                    target = (now + timedelta(days=1)).replace(
-                        hour=8, minute=0, second=0, microsecond=0
-                    )
-                facebook_service.schedule_post_to_facebook_page(
-                    last_post, target, selected_image_path
-                )
-                telegram_service.send_message("Publication planifiée.")
-                last_post = None
-                selected_image_path = None
-                logger.info("Publication programmée avec succès.")
-                continue
-
-            # Par défaut, le message est transmis à OpenAI pour générer un post
             last_post = openai_service.generate_event_post(text)
-            telegram_service.send_message(last_post)
-            logger.info("Post généré avec succès.")
+            selected_image_path: str | None = None
+
+            while True:
+                action = telegram_service.send_message_with_buttons(
+                    last_post,
+                    ["Modifier", "Illustrer", "Publier", "Programmer", "Terminer"],
+                )
+
+                if action == "Modifier":
+                    corrections = telegram_service.ask_text(
+                        "Partagez vos modifications s'il vous plaît !"
+                    )
+                    last_post = openai_service.apply_corrections(
+                        last_post, corrections
+                    )
+                    continue
+
+                if action == "Illustrer":
+                    styles = [
+                        "Réaliste",
+                        "Dessin animé",
+                        "Pixel art",
+                        "Manga",
+                        "Aquarelle",
+                        "Croquis",
+                        "Peinture à l'huile",
+                        "Low poly",
+                        "Cyberpunk",
+                        "Art déco",
+                        "Noir et blanc",
+                        "Fantaisie",
+                    ]
+                    style = telegram_service.ask_options(
+                        "Choisissez un style d'illustration", styles
+                    )
+                    illustrations = openai_service.generate_illustrations(
+                        last_post, style
+                    )
+                    if illustrations:
+                        chosen_image = telegram_service.ask_image(
+                            "Choisissez une illustration", illustrations
+                        )
+                        if chosen_image:
+                            chosen_image.seek(0)
+                            selected_image_path = "selected_image.png"
+                            with open(selected_image_path, "wb") as fh:
+                                fh.write(chosen_image.getvalue())
+                    continue
+
+                if action == "Publier":
+                    facebook_service.post_to_facebook_page(
+                        last_post, selected_image_path
+                    )
+                    groups = telegram_service.ask_groups()
+                    if groups:
+                        facebook_service.cross_post_to_groups(
+                            last_post, groups, selected_image_path
+                        )
+                    telegram_service.send_message("Publication effectuée.")
+                    logger.info("Post généré avec succès.")
+                    break
+
+                if action == "Programmer":
+                    now = datetime.utcnow()
+                    target = now.replace(hour=20, minute=0, second=0, microsecond=0)
+                    if now >= target:
+                        target = (now + timedelta(days=1)).replace(
+                            hour=8, minute=0, second=0, microsecond=0
+                        )
+                    facebook_service.schedule_post_to_facebook_page(
+                        last_post, target, selected_image_path
+                    )
+                    telegram_service.send_message("Publication planifiée.")
+                    logger.info("Publication programmée avec succès.")
+                    break
+
+                if action == "Terminer":
+                    break
         except Exception as err:  # pragma: no cover - log then continue
             logger.exception(f"Erreur lors du traitement : {err}")
 


### PR DESCRIPTION
## Summary
- send Telegram messages with inline buttons and wait for selection
- drive the audio post workflow via buttons instead of slash commands
- cover button-driven interaction with new unit test

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68a72b6f22208325b63fb54b9517f63c