### PR TITLE
Add Odoo email marketing workflow

### DIFF
--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -1,0 +1,83 @@
+"""Workflow de création d'email marketing via Telegram."""
+
+from datetime import datetime, timedelta
+from services.openai_service import OpenAIService
+from services.telegram_service import TelegramService
+from services.odoo_email_service import OdooEmailService
+from config.log_config import setup_logger, log_execution
+
+
+@log_execution
+def main() -> None:
+    logger = setup_logger(__name__)
+
+    openai_service = OpenAIService(logger)
+    telegram_service = TelegramService(logger, openai_service)
+    telegram_service.start()
+    try:
+        email_service = OdooEmailService(logger)
+    except RuntimeError as err:
+        logger.exception(f"Initialisation du service Odoo échouée : {err}")
+        telegram_service.send_message(str(err))
+        return
+
+    telegram_service.send_message("Prêt pour l'email marketing !")
+
+    while True:
+        text = telegram_service.wait_for_message()
+        if not text:
+            break
+
+        try:
+            subject, body = openai_service.generate_marketing_email(text)
+            links: list[str] = []
+            while True:
+                preview = f"Objet: {subject}\n\n{body}"
+                action = telegram_service.send_message_with_buttons(
+                    preview,
+                    ["Modifier", "Liens", "Publier", "Programmer", "Terminer"],
+                )
+
+                if action == "Modifier":
+                    corrections = telegram_service.ask_text(
+                        "Partagez vos modifications s'il vous plaît !"
+                    )
+                    body = openai_service.apply_corrections(body, corrections)
+                    continue
+
+                if action == "Liens":
+                    link_text = telegram_service.ask_text(
+                        "Fournissez les liens séparés par des espaces ou retours à la ligne"
+                    )
+                    new_links = [l.strip() for l in link_text.split() if l.strip()]
+                    links.extend(new_links)
+                    continue
+
+                if action == "Publier":
+                    email_service.schedule_email(
+                        subject, body, links, datetime.utcnow()
+                    )
+                    telegram_service.send_message("Email envoyé.")
+                    break
+
+                if action == "Programmer":
+                    now = datetime.utcnow()
+                    days_ahead = (2 - now.weekday()) % 7  # 2 = mercredi
+                    target = (now + timedelta(days=days_ahead)).replace(
+                        hour=6, minute=0, second=0, microsecond=0
+                    )
+                    if target <= now:
+                        target += timedelta(days=7)
+                    email_service.schedule_email(subject, body, links, target)
+                    telegram_service.send_message("Email programmé.")
+                    break
+
+                if action == "Terminer":
+                    break
+        except Exception as err:  # pragma: no cover - log then continue
+            logger.exception(f"Erreur lors du traitement : {err}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/services/odoo_email_service.py
+++ b/services/odoo_email_service.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+from typing import List
+
+from config.log_config import log_execution
+from config.odoo_connect import get_odoo_connection
+
+
+class OdooEmailService:
+    """Service pour créer et planifier des emails marketing via Odoo."""
+
+    @log_execution
+    def __init__(self, logger) -> None:
+        self.logger = logger
+        self.db, self.uid, self.password, self.models = get_odoo_connection()
+
+    @log_execution
+    def schedule_email(
+        self, subject: str, body: str, links: List[str], send_datetime: datetime
+    ) -> int:
+        """Crée et programme un email marketing.
+
+        Parameters
+        ----------
+        subject: str
+            Objet de l'email.
+        body: str
+            Contenu principal de l'email (HTML ou texte).
+        links: List[str]
+            Liste d'URL à ajouter au contenu.
+        send_datetime: datetime
+            Date et heure d'envoi (UTC).
+
+        Returns
+        -------
+        int
+            L'identifiant de l'email créé.
+        """
+
+        links_html = "<br>".join(
+            f'<a href="{url}">{url}</a>' for url in links
+        ) if links else ""
+        body_html = f"<p>{body}</p>"
+        if links_html:
+            body_html += f"<br>{links_html}"
+
+        mailing_id = self.models.execute_kw(
+            self.db,
+            self.uid,
+            self.password,
+            "mailing.mailing",
+            "create",
+            [
+                {
+                    "subject": subject,
+                    "body_html": body_html,
+                    "mailing_type": "mail",
+                    "schedule_date": send_datetime.strftime("%Y-%m-%d %H:%M:%S"),
+                }
+            ],
+        )
+
+        self.models.execute_kw(
+            self.db,
+            self.uid,
+            self.password,
+            "mailing.mailing",
+            "action_schedule",
+            [[mailing_id]],
+        )
+        return mailing_id

--- a/tests/test_odoo_email_service.py
+++ b/tests/test_odoo_email_service.py
@@ -1,0 +1,49 @@
+import logging
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from services.odoo_email_service import OdooEmailService
+
+
+def test_schedule_email_calls_odoo(monkeypatch):
+    mock_models = MagicMock()
+    mock_models.execute_kw.side_effect = [1, True]
+
+    def fake_connect():
+        return ("db", 1, "pwd", mock_models)
+
+    monkeypatch.setattr(
+        "services.odoo_email_service.get_odoo_connection", fake_connect
+    )
+
+    service = OdooEmailService(logging.getLogger("test"))
+    dt = datetime(2024, 5, 29, 6, 0)
+    mailing_id = service.schedule_email("Sujet", "Corps", ["http://ex"], dt)
+
+    assert mailing_id == 1
+    expected_body = (
+        "<p>Corps</p><br><a href=\"http://ex\">http://ex</a>"
+    )
+    mock_models.execute_kw.assert_any_call(
+        "db",
+        1,
+        "pwd",
+        "mailing.mailing",
+        "create",
+        [
+            {
+                "subject": "Sujet",
+                "body_html": expected_body,
+                "mailing_type": "mail",
+                "schedule_date": "2024-05-29 06:00:00",
+            }
+        ],
+    )
+    mock_models.execute_kw.assert_any_call(
+        "db",
+        1,
+        "pwd",
+        "mailing.mailing",
+        "action_schedule",
+        [[1]],
+    )

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -68,6 +68,16 @@ def test_apply_corrections(monkeypatch):
     assert "Correction" in messages[1]["content"]
 
 
+def test_generate_marketing_email(monkeypatch):
+    dummy_client = DummyClient(content="Objet\n\nCorps")
+    monkeypatch.setattr("services.openai_service.OpenAI", lambda: dummy_client)
+    service = OpenAIService(DummyLogger())
+
+    subject, body = service.generate_marketing_email("Infos")
+    assert subject == "Objet"
+    assert body == "Corps"
+
+
 @patch("services.openai_service.OpenAI")
 def test_generate_illustrations_returns_bytesio(mock_openai):
     mock_client = MagicMock()


### PR DESCRIPTION
## Summary
- extend OpenAI service to craft marketing emails with subject and body
- add OdooEmailService and workflow to schedule email campaigns via Telegram
- cover new functionality with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7758067348325b023b144488c4929