### PR TITLE
Use real XML-RPC connection for Odoo

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -8,9 +8,11 @@ and documented here for clarity.
 import os
 from dotenv import load_dotenv
 from .group_data_loader import load_group_data
+from config.log_config import setup_logger
 
 # Load variables from the .env file once
 load_dotenv()
+logger = setup_logger(__name__)
 
 # --- OpenAI configuration -----------------------------------------------------
 # Used by ``openai_utils`` and ``services.openai_service`` to authenticate calls
@@ -33,3 +35,11 @@ TELEGRAM_USER_ID = int(os.getenv("TELEGRAM_USER_ID", "0"))
 # Required by the Facebook posting utilities to publish on a page.
 FACEBOOK_PAGE_ID = os.getenv("FACEBOOK_PAGE_ID", "")
 PAGE_ACCESS_TOKEN = os.getenv("PAGE_ACCESS_TOKEN", "")
+
+# --- Test Odoo connection -----------------------------------------------------
+try:
+    from pos_category_management.manage_pos_categories import update_pos_categories
+
+    update_pos_categories()
+except Exception as exc:
+    logger.exception("Erreur lors du test de connexion à Odoo : %s", exc)

--- a/config/auth.py
+++ b/config/auth.py
@@ -1,18 +1,19 @@
 # config/auth.py
 
 from config.log_config import setup_logger
+import xmlrpc.client
 
 
 logger = setup_logger(__name__)
 
 
 def authenticate_odoo(url, db, username, password):
-    """Simule l'authentification Odoo pour les tests hors ligne."""
+    """Authenticate against a real Odoo instance using XML-RPC."""
     logger.info("Tentative d'authentification Odoo...")
-    if password == "mauvais_mot_de_passe":
+    common = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/common")
+    uid = common.authenticate(db, username, password, {})
+    if not uid:
         logger.error("Échec de l'authentification Odoo : identifiants invalides.")
         raise Exception("Échec de l'authentification Odoo.")
-    # Retourne un UID fictif sans contacter un serveur distant
-    uid = 1
     logger.info(f"Authentification Odoo réussie (uid={uid}).")
     return uid

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,15 +1,39 @@
-# tests/test_auth.py
+"""Tests for authentication against the Odoo XML-RPC API."""
 
 import unittest
-import config
+from unittest.mock import MagicMock, patch
+import importlib
 from config.auth import authenticate_odoo
 
 class TestAuthOdoo(unittest.TestCase):
     def setUp(self):
+        common = MagicMock()
+
+        def _authenticate(db, username, password, _):
+            return False if password == "mauvais_mot_de_passe" else 1
+
+        common.authenticate.side_effect = _authenticate
+        models = MagicMock()
+        models.execute_kw.return_value = []
+
+        def server_proxy(url):
+            if url.endswith("/common"):
+                return common
+            if url.endswith("/object"):
+                return models
+            return MagicMock()
+
+        self.patcher = patch("xmlrpc.client.ServerProxy", side_effect=server_proxy)
+        self.patcher.start()
+
+        import config
+        importlib.reload(config)
+        self.config = config
         self.url = config.ODOO_URL
         self.db = config.ODOO_DB
         self.username = config.ODOO_USER
         self.password = config.ODOO_PASSWORD
+        self.addCleanup(self.patcher.stop)
 
     def test_authenticate_success(self):
         uid = authenticate_odoo(self.url, self.db, self.username, self.password)

--- a/tests/test_facebook_service.py
+++ b/tests/test_facebook_service.py
@@ -1,12 +1,27 @@
-import logging
-import unittest
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, MagicMock, mock_open, patch
 import pytest
 import requests
+import logging
+import unittest
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+import importlib
 
+
+def _server_proxy(url):
+    common = MagicMock()
+    common.authenticate.return_value = 1
+    models = MagicMock()
+    models.execute_kw.return_value = []
+    if url.endswith("/common"):
+        return common
+    return models
+
+
+_patcher = patch("xmlrpc.client.ServerProxy", side_effect=_server_proxy)
+_patcher.start()
 import config
+importlib.reload(config)
+_patcher.stop()
 from services.facebook_service import FacebookService
 
 

--- a/tests/test_odoo_connect.py
+++ b/tests/test_odoo_connect.py
@@ -1,23 +1,51 @@
-# tests/test_odoo_connect.py
+"""Tests for establishing a connection to Odoo via XML-RPC."""
 
 import unittest
-from config.odoo_connect import get_odoo_connection
+from unittest.mock import MagicMock, patch
+import importlib
 
 class TestOdooConnect(unittest.TestCase):
+    def setUp(self):
+        common = MagicMock()
+
+        def _authenticate(db, username, password, _):
+            return 1
+
+        common.authenticate.side_effect = _authenticate
+        models = MagicMock()
+
+        def _execute_kw(db, uid, password, model, method, args=None, kwargs=None):
+            if model == "product.template" and method == "search_count":
+                return 42
+            return []
+
+        models.execute_kw.side_effect = _execute_kw
+
+        def server_proxy(url):
+            if url.endswith("/common"):
+                return common
+            if url.endswith("/object"):
+                return models
+            return MagicMock()
+
+        self.patcher = patch("xmlrpc.client.ServerProxy", side_effect=server_proxy)
+        self.patcher.start()
+
+        import config
+        importlib.reload(config)
+        import config.odoo_connect as odoo_connect
+        importlib.reload(odoo_connect)
+        self.get_odoo_connection = odoo_connect.get_odoo_connection
+        self.addCleanup(self.patcher.stop)
+
     def test_connection(self):
-        try:
-            db, uid, password, models = get_odoo_connection()
-            self.assertIsNotNone(uid, "L'UID utilisateur ne doit pas être None après connexion.")
-        except Exception as e:
-            self.fail(f"Erreur lors de la connexion à Odoo : {e}")
+        db, uid, password, models = self.get_odoo_connection()
+        self.assertIsNotNone(uid, "L'UID utilisateur ne doit pas être None après connexion.")
 
     def test_product_count(self):
-        try:
-            db, uid, password, models = get_odoo_connection()
-            count = models.execute_kw(db, uid, password, 'product.template', 'search_count', [[]])
-            self.assertIsInstance(count, int, "Le nombre de produits doit être un entier.")
-        except Exception as e:
-            self.fail(f"Erreur lors du comptage des produits Odoo : {e}")
+        db, uid, password, models = self.get_odoo_connection()
+        count = models.execute_kw(db, uid, password, 'product.template', 'search_count', [[]])
+        self.assertIsInstance(count, int, "Le nombre de produits doit être un entier.")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Authenticate against Odoo using `xmlrpc.client` and raise an exception on failure
- Return a real XML-RPC model proxy from `get_odoo_connection`
- Load Odoo settings from the environment and trigger a POS category update
- Mock XML-RPC calls in tests to avoid network dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8044994c08325b0064e40237aa076