### PR TITLE
Stop email workflow on Terminer

### DIFF
--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -73,7 +73,8 @@ def main() -> None:
                     break
 
                 if action == "Terminer":
-                    break
+                    telegram_service.send_message("Fin du workflow email.")
+                    return
         except Exception as err:  # pragma: no cover - log then continue
             logger.exception(f"Erreur lors du traitement : {err}")
 


### PR DESCRIPTION
## Summary
- terminate the email workflow when the user presses **Terminer**
- notify the user the workflow has ended

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8179c6fa08325a70ac07273e542f7