### PR TITLE
refactor: trigger POS category update manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Ces variables permettent de se connecter à Odoo, à l'API OpenAI, à Facebook e
   python generate_post/generate_facebook_post.py
   python generate_post/generate_linkedin_post.py
   ```
-- Mettre à jour automatiquement les catégories POS selon le jour :
+- Mettre à jour manuellement les catégories POS selon le jour :
   ```bash
-  python pos_category_management/manage_pos_categories.py
+  python pos_category_management/update_categories.py
   ```
   Ce script active BUVETTE, EPICERIE et BUREAU le vendredi à partir de 6h, puis BUVETTE, EPICERIE, BUREAU et FOURNIL le dimanche à partir de 6h. Les autres jours, ces catégories sont désactivées.
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -35,11 +35,3 @@ TELEGRAM_USER_ID = int(os.getenv("TELEGRAM_USER_ID", "0"))
 # Required by the Facebook posting utilities to publish on a page.
 FACEBOOK_PAGE_ID = os.getenv("FACEBOOK_PAGE_ID", "")
 PAGE_ACCESS_TOKEN = os.getenv("PAGE_ACCESS_TOKEN", "")
-
-# --- Test Odoo connection -----------------------------------------------------
-try:
-    from pos_category_management.manage_pos_categories import update_pos_categories
-
-    update_pos_categories()
-except Exception as exc:
-    logger.exception("Erreur lors du test de connexion à Odoo : %s", exc)

--- a/pos_category_management/update_categories.py
+++ b/pos_category_management/update_categories.py
@@ -1,0 +1,12 @@
+"""Trigger manual POS category update."""
+
+from pos_category_management.manage_pos_categories import update_pos_categories
+
+
+def main() -> None:
+    """Run the category update process."""
+    update_pos_categories()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- decouple POS category update from configuration
- add dedicated script to trigger category updates
- document manual POS category update in README

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68a81b8e4c3083258e2cb77826739b1b