### PR TITLE
Allow XML-RPC None values

### DIFF
--- a/config/auth.py
+++ b/config/auth.py
@@ -10,7 +10,9 @@ logger = setup_logger(__name__)
 def authenticate_odoo(url, db, username, password):
     """Authenticate against a real Odoo instance using XML-RPC."""
     logger.info("Tentative d'authentification Odoo...")
-    common = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/common")
+    common = xmlrpc.client.ServerProxy(
+        f"{url}/xmlrpc/2/common", allow_none=True
+    )
     uid = common.authenticate(db, username, password, {})
     if not uid:
         logger.error("Échec de l'authentification Odoo : identifiants invalides.")

--- a/config/odoo_connect.py
+++ b/config/odoo_connect.py
@@ -31,7 +31,9 @@ def get_odoo_connection():
         uid = authenticate_odoo(url, db, username, password)
 
         # Proxy XML-RPC pour les objets Odoo
-        models = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/object")
+        models = xmlrpc.client.ServerProxy(
+            f"{url}/xmlrpc/2/object", allow_none=True
+        )
         logger.info("Connexion à Odoo établie.")
 
         return db, uid, password, models

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -16,7 +16,7 @@ class TestAuthOdoo(unittest.TestCase):
         models = MagicMock()
         models.execute_kw.return_value = []
 
-        def server_proxy(url):
+        def server_proxy(url, *args, **kwargs):
             if url.endswith("/common"):
                 return common
             if url.endswith("/object"):

--- a/tests/test_odoo_connect.py
+++ b/tests/test_odoo_connect.py
@@ -21,7 +21,7 @@ class TestOdooConnect(unittest.TestCase):
 
         models.execute_kw.side_effect = _execute_kw
 
-        def server_proxy(url):
+        def server_proxy(url, *args, **kwargs):
             if url.endswith("/common"):
                 return common
             if url.endswith("/object"):


### PR DESCRIPTION
## Summary
- permit XML-RPC requests/responses to include `None` by setting `allow_none=True`
- adjust tests to accept additional `ServerProxy` kwargs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8200fc4108325adaeb8c7af5a3fbc