### PR TITLE
feat: allow selecting mailing lists for email marketing

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -25,6 +25,12 @@ ODOO_URL = os.getenv("ODOO_URL", "")
 ODOO_DB = os.getenv("ODOO_DB", "")
 ODOO_USER = os.getenv("ODOO_USER", "")
 ODOO_PASSWORD = os.getenv("ODOO_PASSWORD", "")
+# Comma-separated list IDs of mailing lists targeted by default.
+# Falls back to mailing list ID ``2`` when unspecified.
+_list_ids = os.getenv("ODOO_MAILING_LIST_IDS", "2")
+ODOO_MAILING_LIST_IDS = [
+    int(_id.strip()) for _id in _list_ids.split(",") if _id.strip()
+]
 
 # --- Telegram configuration ---------------------------------------------------
 # Used by ``telegram_service`` to send notifications to a specific user.

--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -9,6 +9,7 @@ from services.openai_service import OpenAIService
 from services.telegram_service import TelegramService
 from services.odoo_email_service import OdooEmailService
 from config.log_config import setup_logger, log_execution
+from config import ODOO_MAILING_LIST_IDS
 
 
 @log_execution
@@ -74,7 +75,9 @@ def main() -> None:
                     target = datetime.now(tz)
                     target_utc = target.astimezone(utc)
                     try:
-                        email_service.schedule_email(subject, body, links, target_utc)
+                        email_service.schedule_email(
+                            subject, body, links, target_utc, ODOO_MAILING_LIST_IDS
+                        )
                         telegram_service.send_message("Email envoyé.")
                     except xmlrpc.client.Fault as err:
                         logger.exception(
@@ -96,7 +99,7 @@ def main() -> None:
                     target_utc = target.astimezone(utc)
                     try:
                         email_service.schedule_email(
-                            subject, body, links, target_utc
+                            subject, body, links, target_utc, ODOO_MAILING_LIST_IDS
                         )
                         telegram_service.send_message("Email programmé.")
                     except xmlrpc.client.Fault as err:

--- a/services/odoo_email_service.py
+++ b/services/odoo_email_service.py
@@ -1,9 +1,10 @@
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 from zoneinfo import ZoneInfo
 
 from config.log_config import log_execution
 from config.odoo_connect import get_odoo_connection
+from config import ODOO_MAILING_LIST_IDS
 
 
 class OdooEmailService:
@@ -13,10 +14,26 @@ class OdooEmailService:
     def __init__(self, logger) -> None:
         self.logger = logger
         self.db, self.uid, self.password, self.models = get_odoo_connection()
+        # Retrieve model id for mailing.list once
+        model_ids = self.models.execute_kw(
+            self.db,
+            self.uid,
+            self.password,
+            "ir.model",
+            "search",
+            [[("model", "=", "mailing.list")]],
+            {"limit": 1},
+        )
+        self.mailing_model_id = model_ids[0] if model_ids else None
 
     @log_execution
     def schedule_email(
-        self, subject: str, body: str, links: List[str], send_datetime: datetime
+        self,
+        subject: str,
+        body: str,
+        links: List[str],
+        send_datetime: datetime,
+        list_ids: Optional[List[int]] = None,
     ) -> int:
         """Crée et programme un email marketing.
 
@@ -37,6 +54,9 @@ class OdooEmailService:
             L'identifiant de l'email créé.
         """
 
+        if list_ids is None:
+            list_ids = ODOO_MAILING_LIST_IDS
+
         links_html = (
             "<br>".join(f'<a href="{url}">{url}</a>' for url in links)
             if links
@@ -46,22 +66,27 @@ class OdooEmailService:
         if links_html:
             body_html += f"<br>{links_html}"
 
+        create_vals = {
+            "subject": subject,
+            "body_html": body_html,
+            "mailing_type": "mail",
+            "schedule_type": "scheduled",
+            "schedule_date": send_datetime.astimezone(ZoneInfo("UTC")).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
+        }
+        if self.mailing_model_id:
+            create_vals["mailing_model_id"] = self.mailing_model_id
+        if list_ids:
+            create_vals["contact_list_ids"] = [(6, 0, list_ids)]
+
         mailing_id = self.models.execute_kw(
             self.db,
             self.uid,
             self.password,
             "mailing.mailing",
             "create",
-            [
-                {
-                    "subject": subject,
-                    "body_html": body_html,
-                    "mailing_type": "mail",
-                    "schedule_date": send_datetime.astimezone(
-                        ZoneInfo("UTC")
-                    ).strftime("%Y-%m-%d %H:%M:%S"),
-                }
-            ],
+            [create_vals],
         )
 
         self.models.execute_kw(


### PR DESCRIPTION
## Summary
- support default mailing list IDs via `ODOO_MAILING_LIST_IDS`
- allow `OdooEmailService.schedule_email` to target specific mailing lists and set schedule metadata
- pass mailing list IDs in `odoo_email_workflow` and adjust tests
- default to mailing list ID 2 when no list IDs specified

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a821fe66f883258b07439510aded66