### PR TITLE
Add link tracking and sender config to Odoo emails

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -32,6 +32,10 @@ ODOO_MAILING_LIST_IDS = [
     int(_id.strip()) for _id in _list_ids.split(",") if _id.strip()
 ]
 
+# Default sender address for emails created via ``OdooEmailService``.
+# An empty value will trigger a runtime error when the service is initialised.
+ODOO_EMAIL_FROM = os.getenv("ODOO_EMAIL_FROM", "")
+
 # --- Telegram configuration ---------------------------------------------------
 # Used by ``telegram_service`` to send notifications to a specific user.
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")

--- a/tests/test_odoo_email_service.py
+++ b/tests/test_odoo_email_service.py
@@ -8,13 +8,16 @@ from services.odoo_email_service import OdooEmailService
 
 def test_schedule_email_calls_odoo(monkeypatch):
     mock_models = MagicMock()
-    mock_models.execute_kw.side_effect = [[99], 1, True]
+    mock_models.execute_kw.side_effect = [[99], 42, 1, True]
 
     def fake_connect():
         return ("db", 1, "pwd", mock_models)
 
     monkeypatch.setattr(
         "services.odoo_email_service.get_odoo_connection", fake_connect
+    )
+    monkeypatch.setattr(
+        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
     )
 
     service = OdooEmailService(logging.getLogger("test"))
@@ -29,6 +32,14 @@ def test_schedule_email_calls_odoo(monkeypatch):
         "db",
         1,
         "pwd",
+        "link.tracker",
+        "create",
+        [{"url": "http://ex"}],
+    )
+    mock_models.execute_kw.assert_any_call(
+        "db",
+        1,
+        "pwd",
         "mailing.mailing",
         "create",
         [
@@ -37,9 +48,11 @@ def test_schedule_email_calls_odoo(monkeypatch):
                 "body_html": expected_body,
                 "mailing_type": "mail",
                 "schedule_type": "scheduled",
+                "email_from": "sender@example.com",
                 "schedule_date": "2024-05-29 06:00:00",
                 "mailing_model_id": 99,
                 "contact_list_ids": [(6, 0, [7])],
+                "links_ids": [(6, 0, [42])],
             }
         ],
     )
@@ -63,6 +76,9 @@ def test_schedule_email_uses_default_list(monkeypatch):
     monkeypatch.setattr(
         "services.odoo_email_service.get_odoo_connection", fake_connect
     )
+    monkeypatch.setattr(
+        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
+    )
 
     service = OdooEmailService(logging.getLogger("test"))
     dt = datetime(2024, 5, 29, 8, 0, tzinfo=ZoneInfo("Europe/Paris"))
@@ -81,6 +97,7 @@ def test_schedule_email_uses_default_list(monkeypatch):
                 "body_html": "<p>Corps</p>",
                 "mailing_type": "mail",
                 "schedule_type": "scheduled",
+                "email_from": "sender@example.com",
                 "schedule_date": "2024-05-29 06:00:00",
                 "mailing_model_id": 99,
                 "contact_list_ids": [(6, 0, [2])],


### PR DESCRIPTION
## Summary
- require configured sender address for Odoo emails
- create link tracker records for email URLs and attach via links_ids
- test coverage updated

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a827ba43808325b464727da07d5cb5