### PR TITLE
Fix schedule_email invalid links_ids field

### DIFF
--- a/services/odoo_email_service.py
+++ b/services/odoo_email_service.py
@@ -68,21 +68,11 @@ class OdooEmailService:
         if links_html:
             body_html += f"<br>{links_html}"
 
-        link_ids: List[int] = []
-        for url in links:
-            link_id = self.models.execute_kw(
-                self.db,
-                self.uid,
-                self.password,
-                "link.tracker",
-                "create",
-                [{"url": url}],
-            )
-            link_ids.append(link_id)
-
         create_vals = {
+            "name": subject,
             "subject": subject,
             "body_html": body_html,
+            "body_plaintext": body,
             "mailing_type": "mail",
             "schedule_type": "scheduled",
             "email_from": self.email_from,
@@ -94,8 +84,6 @@ class OdooEmailService:
             create_vals["mailing_model_id"] = self.mailing_model_id
         if list_ids:
             create_vals["contact_list_ids"] = [(6, 0, list_ids)]
-        if link_ids:
-            create_vals["links_ids"] = [(6, 0, link_ids)]
 
         mailing_id = self.models.execute_kw(
             self.db,

--- a/tests/test_odoo_email_service.py
+++ b/tests/test_odoo_email_service.py
@@ -9,7 +9,7 @@ from services.odoo_email_service import OdooEmailService
 
 def test_schedule_email_calls_odoo(monkeypatch):
     mock_models = MagicMock()
-    mock_models.execute_kw.side_effect = [[99], 42, 1, True]
+    mock_models.execute_kw.side_effect = [[99], 1, True]
 
     def fake_connect():
         return ("db", 1, "pwd", mock_models)
@@ -33,27 +33,20 @@ def test_schedule_email_calls_odoo(monkeypatch):
         "db",
         1,
         "pwd",
-        "link.tracker",
-        "create",
-        [{"url": "http://ex"}],
-    )
-    mock_models.execute_kw.assert_any_call(
-        "db",
-        1,
-        "pwd",
         "mailing.mailing",
         "create",
         [
             {
+                "name": "Sujet",
                 "subject": "Sujet",
                 "body_html": expected_body,
+                "body_plaintext": "Corps",
                 "mailing_type": "mail",
                 "schedule_type": "scheduled",
                 "email_from": "sender@example.com",
                 "schedule_date": "2024-05-29 06:00:00",
                 "mailing_model_id": 99,
                 "contact_list_ids": [(6, 0, [7])],
-                "links_ids": [(6, 0, [42])],
             }
         ],
     )
@@ -94,8 +87,10 @@ def test_schedule_email_uses_default_list(monkeypatch):
         "create",
         [
             {
+                "name": "Sujet",
                 "subject": "Sujet",
                 "body_html": "<p>Corps</p>",
+                "body_plaintext": "Corps",
                 "mailing_type": "mail",
                 "schedule_type": "scheduled",
                 "email_from": "sender@example.com",


### PR DESCRIPTION
## Summary
- remove manual link tracker management and links_ids assignment
- adjust email scheduling tests for simplified model calls
- include name and plaintext fields for marketing emails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a82c7591a88325a75f28ee40562d1b