### PR TITLE
Fix missing body in scheduled emails

### DIFF
--- a/services/odoo_email_service.py
+++ b/services/odoo_email_service.py
@@ -71,6 +71,7 @@ class OdooEmailService:
         create_vals = {
             "name": subject,
             "subject": subject,
+            "body_arch": body_html,
             "body_html": body_html,
             "body_plaintext": body,
             "mailing_type": "mail",

--- a/tests/test_odoo_email_service.py
+++ b/tests/test_odoo_email_service.py
@@ -39,6 +39,7 @@ def test_schedule_email_calls_odoo(monkeypatch):
             {
                 "name": "Sujet",
                 "subject": "Sujet",
+                "body_arch": expected_body,
                 "body_html": expected_body,
                 "body_plaintext": "Corps",
                 "mailing_type": "mail",
@@ -89,6 +90,7 @@ def test_schedule_email_uses_default_list(monkeypatch):
             {
                 "name": "Sujet",
                 "subject": "Sujet",
+                "body_arch": "<p>Corps</p>",
                 "body_html": "<p>Corps</p>",
                 "body_plaintext": "Corps",
                 "mailing_type": "mail",


### PR DESCRIPTION
## Summary
- include `body_arch` when creating marketing emails so content is preserved in Odoo
- adjust tests expecting the extra field

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a82f3538708325acc65adc56367091