### PR TITLE
feat: add minimalist html template for emails

### DIFF
--- a/services/odoo_email_service.py
+++ b/services/odoo_email_service.py
@@ -30,6 +30,34 @@ class OdooEmailService:
         )
         self.mailing_model_id = model_ids[0] if model_ids else None
 
+    def _format_body(self, body: str, links: List[str]) -> str:
+        """Génère un contenu HTML simple et lisible pour l'email.
+
+        Parameters
+        ----------
+        body: str
+            Texte principal du message.
+        links: List[str]
+            Liste d'URL à intégrer comme liens cliquables.
+
+        Returns
+        -------
+        str
+            HTML complet prêt à être envoyé.
+        """
+
+        links_html = "".join(
+            f'<p><a href="{url}" style="color:#1a0dab;">{url}</a></p>'
+            for url in links
+        )
+        return (
+            "<div style=\"font-family:Arial,sans-serif;line-height:1.6;"
+            "color:#333;max-width:600px;margin:auto;\">"
+            f"<p>{body}</p>"
+            f"{links_html}"
+            "</div>"
+        )
+
     @log_execution
     def schedule_email(
         self,
@@ -61,12 +89,7 @@ class OdooEmailService:
         if list_ids is None:
             list_ids = ODOO_MAILING_LIST_IDS
 
-        links_html = (
-            "<br>".join(f'<a href="{url}">{url}</a>' for url in links) if links else ""
-        )
-        body_html = f"<p>{body}</p>"
-        if links_html:
-            body_html += f"<br>{links_html}"
+        body_html = self._format_body(body, links)
 
         create_vals = {
             "name": subject,

--- a/tests/test_odoo_email_service.py
+++ b/tests/test_odoo_email_service.py
@@ -7,6 +7,27 @@ import xmlrpc.client
 from services.odoo_email_service import OdooEmailService
 
 
+def test_format_body_returns_fragment(monkeypatch):
+    mock_models = MagicMock()
+
+    def fake_connect():
+        return ("db", 1, "pwd", mock_models)
+
+    monkeypatch.setattr(
+        "services.odoo_email_service.get_odoo_connection", fake_connect
+    )
+    monkeypatch.setattr(
+        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
+    )
+
+    service = OdooEmailService(logging.getLogger("test"))
+    html = service._format_body("Corps", ["http://ex"])
+
+    assert "<!DOCTYPE" not in html
+    assert "<html" not in html.lower()
+    assert html.startswith("<div")
+
+
 def test_schedule_email_calls_odoo(monkeypatch):
     mock_models = MagicMock()
     mock_models.execute_kw.side_effect = [[99], 1, True]
@@ -26,9 +47,7 @@ def test_schedule_email_calls_odoo(monkeypatch):
     mailing_id = service.schedule_email("Sujet", "Corps", ["http://ex"], dt, [7])
 
     assert mailing_id == 1
-    expected_body = (
-        "<p>Corps</p><br><a href=\"http://ex\">http://ex</a>"
-    )
+    expected_body = service._format_body("Corps", ["http://ex"])
     mock_models.execute_kw.assert_any_call(
         "db",
         1,
@@ -80,6 +99,7 @@ def test_schedule_email_uses_default_list(monkeypatch):
     mailing_id = service.schedule_email("Sujet", "Corps", [], dt)
 
     assert mailing_id == 1
+    expected_body = service._format_body("Corps", [])
     mock_models.execute_kw.assert_any_call(
         "db",
         1,
@@ -90,8 +110,8 @@ def test_schedule_email_uses_default_list(monkeypatch):
             {
                 "name": "Sujet",
                 "subject": "Sujet",
-                "body_arch": "<p>Corps</p>",
-                "body_html": "<p>Corps</p>",
+                "body_arch": expected_body,
+                "body_html": expected_body,
                 "body_plaintext": "Corps",
                 "mailing_type": "mail",
                 "schedule_type": "scheduled",


### PR DESCRIPTION
## Summary
- style email content with a simple HTML fragment for clarity
- validate email formatting through dedicated test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83372de5c8325a945ff0ba4b1991d