### PR TITLE
Accept preformatted HTML bodies in marketing emails

### DIFF
--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -47,10 +47,10 @@ def main() -> None:
             break
 
         try:
-            subject, body = openai_service.generate_marketing_email(text)
+            subject, html_body = openai_service.generate_marketing_email(text)
             links: list[str] = []
             while True:
-                preview = f"Objet: {subject}\n\n{body}"
+                preview = f"Objet: {subject}\n\n{html_body}"
                 action = telegram_service.send_message_with_buttons(
                     preview,
                     ["Modifier", "Liens", "Publier", "Programmer", "Terminer"],
@@ -60,7 +60,7 @@ def main() -> None:
                     corrections = telegram_service.ask_text(
                         "Partagez vos modifications s'il vous plaît !"
                     )
-                    body = openai_service.apply_corrections(body, corrections)
+                    html_body = openai_service.apply_corrections(html_body, corrections)
                     continue
 
                 if action == "Liens":
@@ -76,7 +76,12 @@ def main() -> None:
                     target_utc = target.astimezone(utc)
                     try:
                         email_service.schedule_email(
-                            subject, body, links, target_utc, ODOO_MAILING_LIST_IDS
+                            subject,
+                            html_body,
+                            links,
+                            target_utc,
+                            ODOO_MAILING_LIST_IDS,
+                            already_html=True,
                         )
                         telegram_service.send_message("Email envoyé.")
                     except xmlrpc.client.Fault as err:
@@ -99,7 +104,12 @@ def main() -> None:
                     target_utc = target.astimezone(utc)
                     try:
                         email_service.schedule_email(
-                            subject, body, links, target_utc, ODOO_MAILING_LIST_IDS
+                            subject,
+                            html_body,
+                            links,
+                            target_utc,
+                            ODOO_MAILING_LIST_IDS,
+                            already_html=True,
                         )
                         telegram_service.send_message("Email programmé.")
                     except xmlrpc.client.Fault as err:

--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -53,17 +53,24 @@ class OpenAIService:
 
     @log_execution
     def generate_marketing_email(self, text: str) -> tuple[str, str]:
-        """Génère un email marketing avec objet et corps séparés.
+        """Génère un email marketing et renvoie l'objet ainsi que le corps HTML.
 
         L'objet est retourné sur la première ligne, suivi d'une ligne vide puis
-        du corps du message. Des marqueurs ``[LIEN]`` peuvent être utilisés pour
-        indiquer les emplacements où insérer des liens."""
+        du corps complet de l'email au format HTML. Des marqueurs ``[LIEN]``
+        peuvent être utilisés pour indiquer les emplacements où insérer des
+        liens.
+
+        Returns
+        -------
+        tuple[str, str]
+            L'objet de l'email et son corps HTML complet.
+        """
 
         user_prompt = (
             "Rédige un email marketing à partir des informations suivantes : "
             f"{text}. Fournis l'objet sur la première ligne, une ligne vide, "
-            "puis le corps de l'email. Utilise des marqueurs [LIEN] pour indiquer "
-            "où placer les liens."
+            "puis le corps complet de l'email en HTML avec les balises <html> et "
+            "<body>. Utilise des marqueurs [LIEN] pour indiquer où placer les liens."
         )
         messages = [
             {"role": "system", "content": self.prompt_system},
@@ -77,10 +84,10 @@ class OpenAIService:
             )
             content = response.choices[0].message.content or ""
             if "\n\n" in content:
-                subject, body = content.split("\n\n", 1)
+                subject, html_body = content.split("\n\n", 1)
             else:
-                subject, body = content, ""
-            return subject.strip(), body.strip()
+                subject, html_body = content, ""
+            return subject.strip(), html_body.strip()
         except Exception as err:  # pragma: no cover - log then ignore
             self.logger.exception(
                 f"Erreur lors de la génération de l'email : {err}"

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -69,13 +69,14 @@ def test_apply_corrections(monkeypatch):
 
 
 def test_generate_marketing_email(monkeypatch):
-    dummy_client = DummyClient(content="Objet\n\nCorps")
+    html = "<html><body><p>Corps</p></body></html>"
+    dummy_client = DummyClient(content=f"Objet\n\n{html}")
     monkeypatch.setattr("services.openai_service.OpenAI", lambda: dummy_client)
     service = OpenAIService(DummyLogger())
 
     subject, body = service.generate_marketing_email("Infos")
     assert subject == "Objet"
-    assert body == "Corps"
+    assert body == html
 
 
 @patch("services.openai_service.OpenAI")


### PR DESCRIPTION
## Summary
- generate full HTML marketing emails from OpenAI and return subject plus formatted HTML body
- allow schedule_email to accept existing HTML bodies and skip internal wrapping
- pass AI-generated HTML directly through the email workflow and test HTML preservation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a837983eb88325b4b5b18e3761cfac