### PR TITLE
fix: strip 'Objet' prefix and add unsubscribe link

### DIFF
--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -50,7 +50,7 @@ def main() -> None:
             subject, html_body = openai_service.generate_marketing_email(text)
             links: list[str] = []
             while True:
-                preview = f"Objet: {subject}\n\n{html_body}"
+                preview = f"{subject}\n\n{html_body}" if subject else html_body
                 action = telegram_service.send_message_with_buttons(
                     preview,
                     ["Modifier", "Liens", "Publier", "Programmer", "Terminer"],

--- a/services/odoo_email_service.py
+++ b/services/odoo_email_service.py
@@ -51,13 +51,35 @@ class OdooEmailService:
             f'<p><a href="{url}" style="color:#1a0dab;">{url}</a></p>'
             for url in links
         )
+        unsubscribe_html = (
+            '<p><a href="/unsubscribe_from_list" '
+            'style="color:#1a0dab;">Se désabonner</a></p>'
+        )
         return (
             "<div style=\"font-family:Arial,sans-serif;line-height:1.6;"
             "color:#333;max-width:600px;margin:auto;\">"
             f"<p>{body}</p>"
             f"{links_html}"
+            f"{unsubscribe_html}"
             "</div>"
         )
+
+    def _append_unsubscribe_link(self, html: str) -> str:
+        """Ajoute le lien de désinscription avant la balise de fermeture."""
+
+        unsubscribe_html = (
+            '<p><a href="/unsubscribe_from_list" '
+            'style="color:#1a0dab;">Se désabonner</a></p>'
+        )
+        body_pattern = re.compile(r"</body>", re.IGNORECASE)
+        if body_pattern.search(html):
+            return body_pattern.sub(unsubscribe_html + "</body>", html, count=1)
+
+        div_pattern = re.compile(r"</div>\s*$", re.IGNORECASE)
+        if div_pattern.search(html):
+            return div_pattern.sub(unsubscribe_html + "</div>", html)
+
+        return html + unsubscribe_html
 
     @log_execution
     def schedule_email(
@@ -101,7 +123,7 @@ class OdooEmailService:
                 f'<p><a href="{url}" style="color:#1a0dab;">{url}</a></p>'
                 for url in links
             )
-            body_html = body + links_html
+            body_html = self._append_unsubscribe_link(body + links_html)
         else:
             body_html = self._format_body(body, links)
 

--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import re
 from io import BytesIO
 from pathlib import Path
 from typing import List
@@ -87,7 +88,8 @@ class OpenAIService:
                 subject, html_body = content.split("\n\n", 1)
             else:
                 subject, html_body = content, ""
-            return subject.strip(), html_body.strip()
+            subject = re.sub(r"^[Oo]bjet\s*:\s*", "", subject).strip()
+            return subject, html_body.strip()
         except Exception as err:  # pragma: no cover - log then ignore
             self.logger.exception(
                 f"Erreur lors de la génération de l'email : {err}"

--- a/tests/test_odoo_email_service.py
+++ b/tests/test_odoo_email_service.py
@@ -26,6 +26,7 @@ def test_format_body_returns_fragment(monkeypatch):
     assert "<!DOCTYPE" not in html
     assert "<html" not in html.lower()
     assert html.startswith("<div")
+    assert "/unsubscribe_from_list" in html
 
 
 def test_schedule_email_calls_odoo(monkeypatch):
@@ -98,6 +99,7 @@ def test_schedule_email_accepts_html(monkeypatch):
     dt = datetime(2024, 5, 29, 8, 0, tzinfo=ZoneInfo("Europe/Paris"))
     html = "<html><body><p>Corps</p></body></html>"
     service._format_body = MagicMock(side_effect=AssertionError("should not be called"))
+    expected_html = service._append_unsubscribe_link(html)
 
     mailing_id = service.schedule_email("Sujet", html, [], dt, already_html=True)
 
@@ -112,8 +114,8 @@ def test_schedule_email_accepts_html(monkeypatch):
             {
                 "name": "Sujet",
                 "subject": "Sujet",
-                "body_arch": html,
-                "body_html": html,
+                "body_arch": expected_html,
+                "body_html": expected_html,
                 "body_plaintext": html,
                 "mailing_type": "mail",
                 "schedule_type": "scheduled",

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -79,6 +79,17 @@ def test_generate_marketing_email(monkeypatch):
     assert body == html
 
 
+def test_generate_marketing_email_strips_prefix(monkeypatch):
+    html = "<html><body><p>Corps</p></body></html>"
+    dummy_client = DummyClient(content=f"Objet : Promotion\n\n{html}")
+    monkeypatch.setattr("services.openai_service.OpenAI", lambda: dummy_client)
+    service = OpenAIService(DummyLogger())
+
+    subject, body = service.generate_marketing_email("Infos")
+    assert subject == "Promotion"
+    assert body == html
+
+
 @patch("services.openai_service.OpenAI")
 def test_generate_illustrations_returns_bytesio(mock_openai):
     mock_client = MagicMock()


### PR DESCRIPTION
## Summary
- sanitize generated email subject to drop any leading `Objet:` label
- avoid displaying placeholder label when previewing emails
- cover subject prefix stripping with unit test
- append unsubscribe link to marketing emails and inject it before closing tags
- verify unsubscribe handling with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83995293c832583f12c1f001a64d5