### PR TITLE
Fix email link insertion and preview

### DIFF
--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -51,6 +51,8 @@ def main() -> None:
             links: list[str] = []
             while True:
                 preview = f"{subject}\n\n{html_body}" if subject else html_body
+                if links:
+                    preview += "\n\n" + "\n".join(links)
                 action = telegram_service.send_message_with_buttons(
                     preview,
                     ["Modifier", "Liens", "Publier", "Programmer", "Terminer"],

--- a/tests/test_odoo_email_service.py
+++ b/tests/test_odoo_email_service.py
@@ -128,6 +128,59 @@ def test_schedule_email_accepts_html(monkeypatch):
     )
 
 
+def test_schedule_email_inserts_links_into_html(monkeypatch):
+    mock_models = MagicMock()
+    mock_models.execute_kw.side_effect = [[99], 1, True]
+
+    def fake_connect():
+        return ("db", 1, "pwd", mock_models)
+
+    monkeypatch.setattr(
+        "services.odoo_email_service.get_odoo_connection", fake_connect
+    )
+    monkeypatch.setattr(
+        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
+    )
+
+    service = OdooEmailService(logging.getLogger("test"))
+    dt = datetime(2024, 5, 29, 8, 0, tzinfo=ZoneInfo("Europe/Paris"))
+    html = "<html><body><p>Corps</p></body></html>"
+
+    mailing_id = service.schedule_email(
+        "Sujet", html, ["http://ex"], dt, already_html=True
+    )
+
+    assert mailing_id == 1
+    expected_html = (
+        "<html><body><p>Corps</p>"
+        '<p><a href="http://ex" style="color:#1a0dab;">http://ex</a></p>'
+        '<p><a href="/unsubscribe_from_list" style="color:#1a0dab;">Se désabonner</a></p>'
+        "</body></html>"
+    )
+    mock_models.execute_kw.assert_any_call(
+        "db",
+        1,
+        "pwd",
+        "mailing.mailing",
+        "create",
+        [
+            {
+                "name": "Sujet",
+                "subject": "Sujet",
+                "body_arch": expected_html,
+                "body_html": expected_html,
+                "body_plaintext": html,
+                "mailing_type": "mail",
+                "schedule_type": "scheduled",
+                "email_from": "sender@example.com",
+                "schedule_date": "2024-05-29 06:00:00",
+                "mailing_model_id": 99,
+                "contact_list_ids": [(6, 0, [2])],
+            }
+        ],
+    )
+
+
 def test_schedule_email_uses_default_list(monkeypatch):
     mock_models = MagicMock()
     mock_models.execute_kw.side_effect = [[99], 1, True]


### PR DESCRIPTION
## Summary
- ensure marketing email links are injected before closing tags so they appear in the final email
- show collected links in the Telegram preview before publishing
- test that HTML emails include user-provided links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a83c72a86483259ee16c3455a56580