### PR TITLE
Replace link placeholders in email workflow

### DIFF
--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -50,9 +50,14 @@ def main() -> None:
             subject, html_body = openai_service.generate_marketing_email(text)
             links: list[str] = []
             while True:
-                preview = f"{subject}\n\n{html_body}" if subject else html_body
-                if links:
-                    preview += "\n\n" + "\n".join(links)
+                preview_body, remaining_links = email_service._replace_link_placeholders(
+                    html_body, links
+                )
+                preview = (
+                    f"{subject}\n\n{preview_body}" if subject else preview_body
+                )
+                if remaining_links:
+                    preview += "\n\n" + "\n".join(remaining_links)
                 action = telegram_service.send_message_with_buttons(
                     preview,
                     ["Modifier", "Liens", "Publier", "Programmer", "Terminer"],


### PR DESCRIPTION
## Summary
- Replace `[LIEN]` markers with actual links in email bodies
- Preview emails with links embedded instead of appended
- Test link placeholder replacement in body formatting and scheduling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83fb08c288325907b235ef19bd801