### PR TITLE
Enhance email workflow links and restart options

### DIFF
--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -98,6 +98,13 @@ def main() -> None:
                         telegram_service.send_message(
                             f"Erreur lors de l'envoi de l'email : {err}"
                         )
+                    final_action = telegram_service.send_message_with_buttons(
+                        "Que souhaitez-vous faire ?", ["Recommencer", "Terminer"]
+                    )
+                    if final_action == "Terminer":
+                        telegram_service.send_message("Fin du workflow email.")
+                        return
+                    telegram_service.send_message("Prêt pour l'email marketing !")
                     break
 
                 if action == "Programmer":
@@ -126,6 +133,13 @@ def main() -> None:
                         telegram_service.send_message(
                             f"Erreur lors de la programmation : {err}"
                         )
+                    final_action = telegram_service.send_message_with_buttons(
+                        "Que souhaitez-vous faire ?", ["Recommencer", "Terminer"]
+                    )
+                    if final_action == "Terminer":
+                        telegram_service.send_message("Fin du workflow email.")
+                        return
+                    telegram_service.send_message("Prêt pour l'email marketing !")
                     break
 
                 if action == "Terminer":

--- a/services/odoo_email_service.py
+++ b/services/odoo_email_service.py
@@ -34,10 +34,11 @@ class OdooEmailService:
     def _replace_link_placeholders(
         self, html: str, links: List[str]
     ) -> tuple[str, List[str]]:
-        """Remplace les balises [LIEN] par les URLs fournies.
+        """Remplace les balises ``[LIEN]`` par les URLs fournies.
 
-        Si la balise précède un mot (par exemple ``[LIEN] Facebook``),
-        l'URL est déplacée après ce mot.
+        Si la balise est immédiatement suivie d'un mot (ex. ``[LIEN] Facebook``),
+        ce mot devient l'ancre cliquable pointant vers l'URL correspondante,
+        sans afficher l'URL en clair.
 
         Parameters
         ----------
@@ -61,19 +62,14 @@ class OdooEmailService:
             match = re.match(r"\s*([^\s<.,!?;:]+)([.,!?;:]?)", after)
             if match:
                 word, punct = match.group(1), match.group(2)
-                anchor = (
-                    f"{word} <a href=\"{url}\" style=\"color:#1a0dab;\">{url}</a>{punct}"
-                )
-                html = (
-                    html[:idx]
-                    + anchor
-                    + after[len(match.group(0)) :]
-                )
+                full = match.group(0)
+                anchor_word = f'<a href="{url}" style="color:#1a0dab;">{word}</a>'
+                replacement = full.replace(word, anchor_word, 1)
+                html = html[:idx] + replacement + after[len(full):]
             else:
                 anchor = f'<a href="{url}" style="color:#1a0dab;">{url}</a>'
                 html = html.replace(placeholder, anchor, 1)
 
-        # Supprime les balises restantes si le nombre de liens est insuffisant
         html = html.replace(placeholder, "")
         return html, remaining
 
@@ -228,4 +224,3 @@ class OdooEmailService:
             else:
                 raise
         return mailing_id
-

--- a/tests/test_odoo_email_service.py
+++ b/tests/test_odoo_email_service.py
@@ -68,7 +68,7 @@ def test_replace_link_placeholder_after_platform(monkeypatch):
     )
 
     assert not remaining
-    assert "Facebook <a href=\"http://fb\"" in html
+    assert '<a href="http://fb" style="color:#1a0dab;">Facebook</a>' in html
     assert "[LIEN]" not in html
 
 def test_schedule_email_calls_odoo(monkeypatch):

--- a/tests/test_odoo_email_workflow.py
+++ b/tests/test_odoo_email_workflow.py
@@ -1,0 +1,91 @@
+import odoo_email_workflow
+from odoo_email_workflow import main as workflow_main
+
+
+class DummyLogger:
+    def info(self, msg):
+        pass
+
+    def exception(self, msg):
+        pass
+
+
+class DummyOpenAIService:
+    def __init__(self, logger):
+        pass
+
+    def generate_marketing_email(self, text):
+        return "Sujet", "Corps"
+
+    def apply_corrections(self, html, corrections):
+        return html
+
+
+class DummyTelegramService:
+    instance = None
+
+    def __init__(self, logger, openai_service):
+        self.logger = logger
+        self.openai_service = openai_service
+        self.messages = ["contenu", "/publier", "/terminer"]
+        self.index = 0
+        self.buttons_calls = []
+        self.sent_messages = []
+        DummyTelegramService.instance = self
+
+    def start(self):
+        pass
+
+    def send_message(self, msg):
+        self.sent_messages.append(msg)
+
+    def wait_for_message(self):
+        msg = self.messages[self.index]
+        self.index += 1
+        return msg
+
+    def send_message_with_buttons(self, text, options):
+        self.buttons_calls.append(options)
+        msg = self.wait_for_message()
+        cmd = msg.lstrip("/").lower()
+        for opt in options:
+            if opt.lower().startswith(cmd):
+                return opt
+        return options[0]
+
+    def ask_text(self, prompt):
+        return ""
+
+
+class DummyOdooEmailService:
+    def __init__(self, logger):
+        self.scheduled = False
+
+    def _replace_link_placeholders(self, html, links):
+        return html, []
+
+    def schedule_email(self, subject, body, links, dt, list_ids, already_html=True):
+        self.scheduled = True
+        return 1
+
+
+def test_final_options(monkeypatch):
+    monkeypatch.setattr(
+        "odoo_email_workflow.setup_logger", lambda name: DummyLogger()
+    )
+    monkeypatch.setattr(
+        "odoo_email_workflow.OpenAIService", DummyOpenAIService
+    )
+    monkeypatch.setattr(
+        "odoo_email_workflow.TelegramService", DummyTelegramService
+    )
+    monkeypatch.setattr(
+        "odoo_email_workflow.OdooEmailService", DummyOdooEmailService
+    )
+    monkeypatch.setattr("odoo_email_workflow.ODOO_MAILING_LIST_IDS", [1])
+
+    workflow_main()
+
+    tg = DummyTelegramService.instance
+    assert ["Recommencer", "Terminer"] in tg.buttons_calls
+    assert "Fin du workflow email." in tg.sent_messages


### PR DESCRIPTION
## Summary
- Convert `[LIEN]` placeholders into anchors using the following word without showing raw URL
- Offer restart/terminate choice after sending or scheduling an email
- Add coverage for new workflow behaviour and link anchoring

## Testing
- `./.venv/bin/python -m pytest tests/test_odoo_email_service.py::test_replace_link_placeholder_after_platform -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a84741282083259c5c3c5b3d3cf98c