### PR TITLE
Hard-code default website and Facebook links for email workflow

### DIFF
--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from services.openai_service import OpenAIService
 from services.telegram_service import TelegramService
-from services.odoo_email_service import OdooEmailService
+from services.odoo_email_service import OdooEmailService, DEFAULT_LINKS
 from config.log_config import setup_logger, log_execution
 from config import ODOO_MAILING_LIST_IDS
 
@@ -48,7 +48,7 @@ def main() -> None:
 
         try:
             subject, html_body = openai_service.generate_marketing_email(text)
-            links: list[str] = []
+            links: list[str] = DEFAULT_LINKS.copy()
             while True:
                 preview_body, remaining_links = email_service._replace_link_placeholders(
                     html_body, links
@@ -75,7 +75,7 @@ def main() -> None:
                         "Fournissez les liens séparés par des espaces ou retours à la ligne"
                     )
                     new_links = [l.strip() for l in link_text.split() if l.strip()]
-                    links.extend(new_links)
+                    links = new_links + [l for l in links if l not in new_links]
                     continue
 
                 if action == "Publier":

--- a/services/odoo_email_service.py
+++ b/services/odoo_email_service.py
@@ -9,6 +9,12 @@ from config.odoo_connect import get_odoo_connection
 from config import ODOO_MAILING_LIST_IDS, ODOO_EMAIL_FROM
 
 
+DEFAULT_LINKS = [
+    "https://www.cdfesplas.com",
+    "https://www.facebook.com/cdfesplas",
+]
+
+
 class OdooEmailService:
     """Service pour créer et planifier des emails marketing via Odoo."""
 
@@ -165,6 +171,7 @@ class OdooEmailService:
 
         if list_ids is None:
             list_ids = ODOO_MAILING_LIST_IDS
+        links = list(links) + [l for l in DEFAULT_LINKS if l not in links]
 
         is_html = already_html or bool(re.search(r"<[^>]+>", body))
         if is_html:


### PR DESCRIPTION
## Summary
- add DEFAULT_LINKS constant with cdfesplas website and Facebook page
- automatically append default links in `schedule_email`
- preload default links in email workflow and prioritize custom event links
- adjust tests for new default links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a84aedc4708325a09c38b416fd654e