### PR TITLE
Fix default marketing link order

### DIFF
--- a/services/odoo_email_service.py
+++ b/services/odoo_email_service.py
@@ -9,9 +9,11 @@ from config.odoo_connect import get_odoo_connection
 from config import ODOO_MAILING_LIST_IDS, ODOO_EMAIL_FROM
 
 
+# Links par défaut pour les emails marketing.
+# L'ordre reflète les canaux privilégiés : Facebook puis site web.
 DEFAULT_LINKS = [
-    "https://www.cdfesplas.com",
     "https://www.facebook.com/cdfesplas",
+    "https://www.cdfesplas.com",
 ]
 
 


### PR DESCRIPTION
## Summary
- ensure default link sequence matches expected Facebook then website order for marketing emails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a85125572c8325b567625ecb93390e