### PR TITLE
Refactor marketing email link integration

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -57,9 +57,7 @@ class OpenAIService:
         """Génère un email marketing et renvoie l'objet ainsi que le corps HTML.
 
         L'objet est retourné sur la première ligne, suivi d'une ligne vide puis
-        du corps complet de l'email au format HTML. Des marqueurs ``[LIEN]``
-        peuvent être utilisés pour indiquer les emplacements où insérer des
-        liens.
+        du corps complet de l'email au format HTML.
 
         Returns
         -------
@@ -71,7 +69,7 @@ class OpenAIService:
             "Rédige un email marketing à partir des informations suivantes : "
             f"{text}. Fournis l'objet sur la première ligne, une ligne vide, "
             "puis le corps complet de l'email en HTML avec les balises <html> et "
-            "<body>. Utilise des marqueurs [LIEN] pour indiquer où placer les liens."
+            "<body>."
         )
         messages = [
             {"role": "system", "content": self.prompt_system},

--- a/tests/test_odoo_email_service.py
+++ b/tests/test_odoo_email_service.py
@@ -7,120 +7,34 @@ import xmlrpc.client
 from services.odoo_email_service import OdooEmailService, DEFAULT_LINKS
 
 
-def test_format_body_returns_fragment(monkeypatch):
+def _setup_service(monkeypatch):
     mock_models = MagicMock()
+    mock_models.execute_kw.return_value = [99]
 
     def fake_connect():
         return ("db", 1, "pwd", mock_models)
 
-    monkeypatch.setattr(
-        "services.odoo_email_service.get_odoo_connection", fake_connect
-    )
-    monkeypatch.setattr(
-        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
-    )
-
+    monkeypatch.setattr("services.odoo_email_service.get_odoo_connection", fake_connect)
+    monkeypatch.setattr("services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com")
     service = OdooEmailService(logging.getLogger("test"))
-    html = service._format_body("Corps", ["http://ex"])
+    return service, mock_models
 
-    assert "<!DOCTYPE" not in html
-    assert "<html" not in html.lower()
-    assert html.startswith("<div")
+
+def test_format_body_includes_links_section(monkeypatch):
+    service, _ = _setup_service(monkeypatch)
+    html = service._format_body("Corps", [("Site", "http://ex")])
+    assert "Liens utiles" in html
+    assert '<a href="http://ex"' in html
     assert "/unsubscribe_from_list" in html
 
 
-def test_format_body_replaces_placeholder(monkeypatch):
-    mock_models = MagicMock()
-
-    def fake_connect():
-        return ("db", 1, "pwd", mock_models)
-
-    monkeypatch.setattr(
-        "services.odoo_email_service.get_odoo_connection", fake_connect
-    )
-    monkeypatch.setattr(
-        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
-    )
-
-    service = OdooEmailService(logging.getLogger("test"))
-    html = service._format_body("Visitez [LIEN]", ["http://ex"])
-
-    assert '<a href="http://ex"' in html
-    assert "[LIEN]" not in html
-
-
-def test_replace_link_placeholder_after_platform(monkeypatch):
-    mock_models = MagicMock()
-
-    def fake_connect():
-        return ("db", 1, "pwd", mock_models)
-
-    monkeypatch.setattr(
-        "services.odoo_email_service.get_odoo_connection", fake_connect
-    )
-    monkeypatch.setattr(
-        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
-    )
-
-    service = OdooEmailService(logging.getLogger("test"))
-    html, remaining = service._replace_link_placeholders(
-        "Consulter [LIEN] Facebook", ["http://fb"]
-    )
-
-    assert not remaining
-    assert '<a href="http://fb" style="color:#1a0dab;">Facebook</a>' in html
-    assert "[LIEN]" not in html
-
-
-def test_replace_link_placeholder_handles_domain_and_phrase(monkeypatch):
-    mock_models = MagicMock()
-
-    def fake_connect():
-        return ("db", 1, "pwd", mock_models)
-
-    monkeypatch.setattr(
-        "services.odoo_email_service.get_odoo_connection", fake_connect
-    )
-    monkeypatch.setattr(
-        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
-    )
-
-    service = OdooEmailService(logging.getLogger("test"))
-    html, remaining = service._replace_link_placeholders(
-        "Visitez [LIEN]cdfesplas.com\nSuivez [LIEN]La page du Comite",
-        ["cdfesplas.com", "facebook.com/page"],
-    )
-
-    assert not remaining
-    assert (
-        '<a href="https://cdfesplas.com" style="color:#1a0dab;">cdfesplas.com</a>'
-        in html
-    )
-    assert (
-        '<a href="https://facebook.com/page" style="color:#1a0dab;">'
-        "La page du Comite</a>" in html
-    )
-
 def test_schedule_email_calls_odoo(monkeypatch):
-    mock_models = MagicMock()
-    mock_models.execute_kw.side_effect = [[99], 1, True]
-
-    def fake_connect():
-        return ("db", 1, "pwd", mock_models)
-
-    monkeypatch.setattr(
-        "services.odoo_email_service.get_odoo_connection", fake_connect
-    )
-    monkeypatch.setattr(
-        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
-    )
-
-    service = OdooEmailService(logging.getLogger("test"))
+    service, mock_models = _setup_service(monkeypatch)
+    mock_models.execute_kw.side_effect = [1, True]
     dt = datetime(2024, 5, 29, 8, 0, tzinfo=ZoneInfo("Europe/Paris"))
-    mailing_id = service.schedule_email("Sujet", "Corps", ["http://ex"], dt, [7])
-
+    mailing_id = service.schedule_email("Sujet", "Corps", [("Nom", "http://ex")], dt, [7])
     assert mailing_id == 1
-    expected_body = service._format_body("Corps", ["http://ex"] + DEFAULT_LINKS)
+    expected_body = service._format_body("Corps", [("Nom", "http://ex")] + DEFAULT_LINKS)
     mock_models.execute_kw.assert_any_call(
         "db",
         1,
@@ -143,46 +57,21 @@ def test_schedule_email_calls_odoo(monkeypatch):
             }
         ],
     )
-    mock_models.execute_kw.assert_any_call(
-        "db",
-        1,
-        "pwd",
-        "mailing.mailing",
-        "action_schedule",
-        [[1]],
-    )
 
 
 def test_schedule_email_accepts_html(monkeypatch):
-    mock_models = MagicMock()
-    mock_models.execute_kw.side_effect = [[99], 1, True]
-
-    def fake_connect():
-        return ("db", 1, "pwd", mock_models)
-
-    monkeypatch.setattr(
-        "services.odoo_email_service.get_odoo_connection", fake_connect
-    )
-    monkeypatch.setattr(
-        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
-    )
-
-    service = OdooEmailService(logging.getLogger("test"))
+    service, mock_models = _setup_service(monkeypatch)
+    mock_models.execute_kw.side_effect = [1, True]
     dt = datetime(2024, 5, 29, 8, 0, tzinfo=ZoneInfo("Europe/Paris"))
     html = "<html><body><p>Corps</p></body></html>"
-    service._format_body = MagicMock(side_effect=AssertionError("should not be called"))
+    links_html = service._build_links_section(DEFAULT_LINKS)
     expected_html = (
         "<html><body><p>Corps</p>"
-        + "".join(
-            f'<p><a href="{url}" style="color:#1a0dab;">{url}</a></p>'
-            for url in DEFAULT_LINKS
-        )
+        + links_html
         + '<p><a href="/unsubscribe_from_list" style="color:#1a0dab;">Se désabonner</a></p>'
         "</body></html>"
     )
-
     mailing_id = service.schedule_email("Sujet", html, [], dt, already_html=True)
-
     assert mailing_id == 1
     mock_models.execute_kw.assert_any_call(
         "db",
@@ -209,35 +98,18 @@ def test_schedule_email_accepts_html(monkeypatch):
 
 
 def test_schedule_email_inserts_links_into_html(monkeypatch):
-    mock_models = MagicMock()
-    mock_models.execute_kw.side_effect = [[99], 1, True]
-
-    def fake_connect():
-        return ("db", 1, "pwd", mock_models)
-
-    monkeypatch.setattr(
-        "services.odoo_email_service.get_odoo_connection", fake_connect
-    )
-    monkeypatch.setattr(
-        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
-    )
-
-    service = OdooEmailService(logging.getLogger("test"))
+    service, mock_models = _setup_service(monkeypatch)
+    mock_models.execute_kw.side_effect = [1, True]
     dt = datetime(2024, 5, 29, 8, 0, tzinfo=ZoneInfo("Europe/Paris"))
     html = "<html><body><p>Corps</p></body></html>"
-
     mailing_id = service.schedule_email(
-        "Sujet", html, ["http://ex"], dt, already_html=True
+        "Sujet", html, [("Nom", "http://ex")], dt, already_html=True
     )
-
     assert mailing_id == 1
+    links_html = service._build_links_section([("Nom", "http://ex")] + DEFAULT_LINKS)
     expected_html = (
         "<html><body><p>Corps</p>"
-        '<p><a href="http://ex" style="color:#1a0dab;">http://ex</a></p>'
-        + "".join(
-            f'<p><a href="{url}" style="color:#1a0dab;">{url}</a></p>'
-            for url in DEFAULT_LINKS
-        )
+        + links_html
         + '<p><a href="/unsubscribe_from_list" style="color:#1a0dab;">Se désabonner</a></p>'
         "</body></html>"
     )
@@ -266,23 +138,10 @@ def test_schedule_email_inserts_links_into_html(monkeypatch):
 
 
 def test_schedule_email_uses_default_list(monkeypatch):
-    mock_models = MagicMock()
-    mock_models.execute_kw.side_effect = [[99], 1, True]
-
-    def fake_connect():
-        return ("db", 1, "pwd", mock_models)
-
-    monkeypatch.setattr(
-        "services.odoo_email_service.get_odoo_connection", fake_connect
-    )
-    monkeypatch.setattr(
-        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
-    )
-
-    service = OdooEmailService(logging.getLogger("test"))
+    service, mock_models = _setup_service(monkeypatch)
+    mock_models.execute_kw.side_effect = [1, True]
     dt = datetime(2024, 5, 29, 8, 0, tzinfo=ZoneInfo("Europe/Paris"))
     mailing_id = service.schedule_email("Sujet", "Corps", [], dt)
-
     assert mailing_id == 1
     expected_body = service._format_body("Corps", DEFAULT_LINKS)
     mock_models.execute_kw.assert_any_call(
@@ -307,91 +166,14 @@ def test_schedule_email_uses_default_list(monkeypatch):
             }
         ],
     )
-    mock_models.execute_kw.assert_any_call(
-        "db",
-        1,
-        "pwd",
-        "mailing.mailing",
-        "action_schedule",
-        [[1]],
-    )
 
-
-def test_schedule_email_replaces_placeholder_in_html(monkeypatch):
-    mock_models = MagicMock()
-    mock_models.execute_kw.side_effect = [[99], 1, True]
-
-    def fake_connect():
-        return ("db", 1, "pwd", mock_models)
-
-    monkeypatch.setattr(
-        "services.odoo_email_service.get_odoo_connection", fake_connect
-    )
-    monkeypatch.setattr(
-        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
-    )
-
-    service = OdooEmailService(logging.getLogger("test"))
-    dt = datetime(2024, 5, 29, 8, 0, tzinfo=ZoneInfo("Europe/Paris"))
-    html = "<html><body><p>Consulter [LIEN]</p></body></html>"
-
-    mailing_id = service.schedule_email(
-        "Sujet", html, ["http://ex"], dt, already_html=True
-    )
-
-    assert mailing_id == 1
-    expected_html = (
-        "<html><body><p>Consulter "
-        '<a href="http://ex" style="color:#1a0dab;">http://ex</a></p>'
-        + "".join(
-            f'<p><a href="{url}" style="color:#1a0dab;">{url}</a></p>'
-            for url in DEFAULT_LINKS
-        )
-        + '<p><a href="/unsubscribe_from_list" style="color:#1a0dab;">Se désabonner</a></p>'
-        "</body></html>"
-    )
-    mock_models.execute_kw.assert_any_call(
-        "db",
-        1,
-        "pwd",
-        "mailing.mailing",
-        "create",
-        [
-            {
-                "name": "Sujet",
-                "subject": "Sujet",
-                "body_arch": expected_html,
-                "body_html": expected_html,
-                "body_plaintext": html,
-                "mailing_type": "mail",
-                "schedule_type": "scheduled",
-                "email_from": "sender@example.com",
-                "schedule_date": "2024-05-29 06:00:00",
-                "mailing_model_id": 99,
-                "contact_list_ids": [(6, 0, [2])],
-            }
-        ],
-    )
 
 def test_schedule_email_handles_none_fault(monkeypatch):
-    mock_models = MagicMock()
+    service, mock_models = _setup_service(monkeypatch)
     fault = xmlrpc.client.Fault(
         1, "TypeError: cannot marshal None unless allow_none is enabled"
     )
-    mock_models.execute_kw.side_effect = [[99], 1, fault]
-
-    def fake_connect():
-        return ("db", 1, "pwd", mock_models)
-
-    monkeypatch.setattr(
-        "services.odoo_email_service.get_odoo_connection", fake_connect
-    )
-    monkeypatch.setattr(
-        "services.odoo_email_service.ODOO_EMAIL_FROM", "sender@example.com"
-    )
-
-    service = OdooEmailService(logging.getLogger("test"))
+    mock_models.execute_kw.side_effect = [1, fault]
     dt = datetime(2024, 5, 29, 8, 0, tzinfo=ZoneInfo("Europe/Paris"))
     mailing_id = service.schedule_email("Sujet", "Corps", [], dt)
-
     assert mailing_id == 1

--- a/tests/test_odoo_email_workflow.py
+++ b/tests/test_odoo_email_workflow.py
@@ -61,8 +61,8 @@ class DummyOdooEmailService:
     def __init__(self, logger):
         self.scheduled = False
 
-    def _replace_link_placeholders(self, html, links):
-        return html, []
+    def format_links_preview(self, links):
+        return ""
 
     def schedule_email(self, subject, body, links, dt, list_ids, already_html=True):
         self.scheduled = True


### PR DESCRIPTION
## Summary
- Delegate link insertion to GPT-generated HTML and append a "Liens utiles" section with named links before the unsubscribe button
- Parse user-supplied `Nom : URL` pairs during the email workflow and show them in previews
- Drop `[LIEN]` placeholders from OpenAI prompts and update default links with names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a85cebaf8883258e3111bf04c271d9