### PR TITLE
Remove publish option from email workflow

### DIFF
--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -59,7 +59,7 @@ def main() -> None:
                 preview = f"{subject}\n\n{preview_body}" if subject else preview_body
                 action = telegram_service.send_message_with_buttons(
                     preview,
-                    ["Modifier", "Liens", "Publier", "Programmer", "Terminer"],
+                    ["Modifier", "Liens", "Programmer", "Terminer"],
                 )
 
                 if action == "Modifier":
@@ -84,35 +84,6 @@ def main() -> None:
                     existing_urls = {u for _, u in new_links}
                     links = new_links + [l for l in links if l[1] not in existing_urls]
                     continue
-
-                if action == "Publier":
-                    target = datetime.now(tz)
-                    target_utc = target.astimezone(utc)
-                    try:
-                        email_service.schedule_email(
-                            subject,
-                            html_body,
-                            links,
-                            target_utc,
-                            ODOO_MAILING_LIST_IDS,
-                            already_html=True,
-                        )
-                        telegram_service.send_message("Email envoyé.")
-                    except xmlrpc.client.Fault as err:
-                        logger.exception(
-                            f"Erreur lors de l'envoi de l'email : {err}"
-                        )
-                        telegram_service.send_message(
-                            f"Erreur lors de l'envoi de l'email : {err}"
-                        )
-                    final_action = telegram_service.send_message_with_buttons(
-                        "Que souhaitez-vous faire ?", ["Recommencer", "Terminer"]
-                    )
-                    if final_action == "Terminer":
-                        telegram_service.send_message("Fin du workflow email.")
-                        return
-                    telegram_service.send_message("Prêt pour l'email marketing !")
-                    break
 
                 if action == "Programmer":
                     now = datetime.now(tz)

--- a/tests/test_odoo_email_workflow.py
+++ b/tests/test_odoo_email_workflow.py
@@ -27,7 +27,7 @@ class DummyTelegramService:
     def __init__(self, logger, openai_service):
         self.logger = logger
         self.openai_service = openai_service
-        self.messages = ["contenu", "/publier", "/terminer"]
+        self.messages = ["contenu", "/programmer", "/terminer"]
         self.index = 0
         self.buttons_calls = []
         self.sent_messages = []


### PR DESCRIPTION
## Summary
- Remove "Publier" action from marketing email workflow to allow scheduling only
- Update related unit test to expect programming flow

## Testing
- `pytest`
- `pytest tests/test_odoo_email_workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8721beb088325a44667c0cf4e0a0a