### PR TITLE
Add restart and terminate options to Facebook post workflow

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -112,9 +112,15 @@ def main() -> None:
                         facebook_service.cross_post_to_groups(
                             last_post, groups, selected_image_paths or None
                         )
-                    telegram_service.send_message("Publication effectuée.")
                     logger.info("Post généré avec succès.")
-                    break
+                    final_action = telegram_service.send_message_with_buttons(
+                        "Publication effectuée.", ["Recommencer", "Terminer"]
+                    )
+                    if final_action == "Recommencer":
+                        break
+                    if final_action == "Terminer":
+                        telegram_service.send_message("Fin du processus.")
+                        return
 
                 if action == "Programmer":
                     now = datetime.utcnow()
@@ -126,9 +132,15 @@ def main() -> None:
                     facebook_service.schedule_post_to_facebook_page(
                         last_post, target, selected_image_paths or None
                     )
-                    telegram_service.send_message("Publication planifiée.")
                     logger.info("Publication programmée avec succès.")
-                    break
+                    final_action = telegram_service.send_message_with_buttons(
+                        "Publication planifiée.", ["Recommencer", "Terminer"]
+                    )
+                    if final_action == "Recommencer":
+                        break
+                    if final_action == "Terminer":
+                        telegram_service.send_message("Fin du processus.")
+                        return
 
                 if action == "Terminer":
                     telegram_service.send_message("Fin du processus.")

--- a/tests/test_audio_post_workflow.py
+++ b/tests/test_audio_post_workflow.py
@@ -33,7 +33,7 @@ class DummyTelegramService:
     def __init__(self, logger, openai_service):
         self.logger = logger
         self.openai_service = openai_service
-        self.messages = ["transcribed", "/publier", ""]
+        self.messages = ["transcribed", "/publier", "/terminer"]
         self.index = 0
 
     def start(self):
@@ -71,7 +71,7 @@ class DummyTelegramService:
 class EditingDummyTelegramService(DummyTelegramService):
     def __init__(self, logger, openai_service):
         super().__init__(logger, openai_service)
-        self.messages = ["transcribed", "/modifier", "/publier", ""]
+        self.messages = ["transcribed", "/modifier", "/publier", "/terminer"]
 
     def ask_text(self, prompt):
         return "modif"
@@ -106,7 +106,13 @@ class IllustrationDummyOpenAIService(DummyOpenAIService):
 class IllustrationDummyTelegramService(DummyTelegramService):
     def __init__(self, logger, openai_service):
         super().__init__(logger, openai_service)
-        self.messages = ["transcribed", "/illustrer", "/generer", "/publier", ""]
+        self.messages = [
+            "transcribed",
+            "/illustrer",
+            "/generer",
+            "/publier",
+            "/terminer",
+        ]
 
     def ask_options(self, prompt, options):
         assert "style" in prompt.lower()
@@ -141,7 +147,7 @@ def test_main_flow(monkeypatch):
 class SchedulingDummyTelegramService(DummyTelegramService):
     def __init__(self, logger, openai_service):
         super().__init__(logger, openai_service)
-        self.messages = ["transcribed", "/programmer", ""]
+        self.messages = ["transcribed", "/programmer", "/terminer"]
 
 
 def test_scheduling_flow(monkeypatch):
@@ -231,7 +237,7 @@ class AttachDummyTelegramService(DummyTelegramService):
             "/illustrer",
             "/joindre",
             "/publier",
-            "",
+            "/terminer",
         ]
 
     def ask_user_images(self):


### PR DESCRIPTION
## Summary
- Offer Restart and Terminate choices after publishing or scheduling a post
- Update tests for new workflow behavior

## Testing
- `pytest` *(fails: tests/test_odoo_email_service.py::test_schedule_email_calls_odoo, tests/test_odoo_email_service.py::test_schedule_email_accepts_html, tests/test_odoo_email_service.py::test_schedule_email_inserts_links_into_html, tests/test_odoo_email_service.py::test_schedule_email_uses_default_list, tests/test_openai_service.py::test_generate_illustrations_returns_bytesio, tests/test_prompt_builder.py::test_build_user_prompt_fills_fields)*

------
https://chatgpt.com/codex/tasks/task_e_68a874684c84832599c99442ad33c79d