### PR TITLE
Centralize Telegram workflow polling

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -3,14 +3,135 @@
 Le script invite l'utilisateur à envoyer un message vocal ou texte et construit
 un post à partir du contenu obtenu. Les interactions utilisateurs sont
 désormais réalisées via un véritable bot Telegram.
-
 """
 
-from services.openai_service import OpenAIService
 from datetime import datetime, timedelta
-from services.telegram_service import TelegramService
+
 from services.facebook_service import FacebookService
+from services.openai_service import OpenAIService
+from services.telegram_service import TelegramService
 from config.log_config import setup_logger, log_execution
+
+
+@log_execution
+def run_workflow(
+    logger,
+    telegram_service: "TelegramService",
+    openai_service: "OpenAIService",
+    facebook_service: "FacebookService",
+) -> None:
+    """Exécute le workflow de publication avec des services déjà initialisés."""
+
+    telegram_service.send_message("Il est temps de publier Kevin")
+
+    text = telegram_service.wait_for_message()
+    if not text:
+        return
+
+    try:
+        last_post = openai_service.generate_event_post(text)
+        selected_image_paths: list[str] = []
+
+        while True:
+            action = telegram_service.send_message_with_buttons(
+                last_post,
+                ["Modifier", "Illustrer", "Publier", "Programmer", "Terminer"],
+            )
+
+            if action == "Modifier":
+                corrections = telegram_service.ask_text(
+                    "Partagez vos modifications s'il vous plaît !",
+                )
+                last_post = openai_service.apply_corrections(last_post, corrections)
+                continue
+
+            if action == "Illustrer":
+                choice = telegram_service.send_message_with_buttons(
+                    "Comment souhaitez-vous illustrer ?",
+                    ["Générer", "Joindre", "Retour"],
+                )
+                if choice == "Générer":
+                    styles = [
+                        "Réaliste",
+                        "Dessin animé",
+                        "Pixel art",
+                        "Manga",
+                        "Aquarelle",
+                        "Croquis",
+                        "Peinture à l'huile",
+                        "Low poly",
+                        "Cyberpunk",
+                        "Art déco",
+                        "Noir et blanc",
+                        "Fantaisie",
+                    ]
+                    style = telegram_service.ask_options(
+                        "Choisissez un style d'illustration", styles
+                    )
+                    illustrations = openai_service.generate_illustrations(
+                        last_post, style
+                    )
+                    if illustrations:
+                        chosen_image = telegram_service.ask_image(
+                            "Choisissez une illustration", illustrations
+                        )
+                        if chosen_image:
+                            chosen_image.seek(0)
+                            path = f"generated_image_{len(selected_image_paths)}.png"
+                            with open(path, "wb") as fh:
+                                fh.write(chosen_image.getvalue())
+                            selected_image_paths = [path]
+                    continue
+                if choice == "Joindre":
+                    images = telegram_service.ask_user_images()
+                    start = len(selected_image_paths)
+                    for idx, img in enumerate(images):
+                        img.seek(0)
+                        path = f"user_image_{start + idx}.png"
+                        with open(path, "wb") as fh:
+                            fh.write(img.getvalue())
+                        selected_image_paths.append(path)
+                    continue
+                if choice == "Retour":
+                    continue
+
+            if action == "Publier":
+                facebook_service.post_to_facebook_page(
+                    last_post, selected_image_paths or None
+                )
+                logger.info("Post généré avec succès.")
+                final_action = telegram_service.send_message_with_buttons(
+                    "Publication effectuée.", ["Recommencer", "Terminer"]
+                )
+                if final_action == "Recommencer":
+                    return
+                telegram_service.send_message("Fin du processus.")
+                return
+
+            if action == "Programmer":
+                now = datetime.utcnow()
+                target = now.replace(hour=20, minute=0, second=0, microsecond=0)
+                if now >= target:
+                    target = (now + timedelta(days=1)).replace(
+                        hour=8, minute=0, second=0, microsecond=0
+                    )
+                facebook_service.schedule_post_to_facebook_page(
+                    last_post, target, selected_image_paths or None
+                )
+                logger.info("Publication programmée avec succès.")
+                final_action = telegram_service.send_message_with_buttons(
+                    "Publication planifiée.", ["Recommencer", "Terminer"]
+                )
+                if final_action == "Recommencer":
+                    return
+                telegram_service.send_message("Fin du processus.")
+                return
+
+            if action == "Terminer":
+                telegram_service.send_message("Fin du processus.")
+                return
+    except Exception as err:  # pragma: no cover - log then continue
+        logger.exception(f"Erreur lors du traitement : {err}")
 
 
 @log_execution
@@ -27,122 +148,9 @@ def main() -> None:
         telegram_service.send_message(str(err))
         return
 
-    telegram_service.send_message("Il est temps de publier Kevin")
-
-    while True:
-        text = telegram_service.wait_for_message()
-        if not text:
-            break
-
-        try:
-            last_post = openai_service.generate_event_post(text)
-            selected_image_paths: list[str] = []
-
-            while True:
-                action = telegram_service.send_message_with_buttons(
-                    last_post,
-                    ["Modifier", "Illustrer", "Publier", "Programmer", "Terminer"],
-                )
-
-                if action == "Modifier":
-                    corrections = telegram_service.ask_text(
-                        "Partagez vos modifications s'il vous plaît !"
-                    )
-                    last_post = openai_service.apply_corrections(
-                        last_post, corrections
-                    )
-                    continue
-
-                if action == "Illustrer":
-                    choice = telegram_service.send_message_with_buttons(
-                        "Comment souhaitez-vous illustrer ?",
-                        ["Générer", "Joindre", "Retour"],
-                    )
-                    if choice == "Générer":
-                        styles = [
-                            "Réaliste",
-                            "Dessin animé",
-                            "Pixel art",
-                            "Manga",
-                            "Aquarelle",
-                            "Croquis",
-                            "Peinture à l'huile",
-                            "Low poly",
-                            "Cyberpunk",
-                            "Art déco",
-                            "Noir et blanc",
-                            "Fantaisie",
-                        ]
-                        style = telegram_service.ask_options(
-                            "Choisissez un style d'illustration", styles
-                        )
-                        illustrations = openai_service.generate_illustrations(
-                            last_post, style
-                        )
-                        if illustrations:
-                            chosen_image = telegram_service.ask_image(
-                                "Choisissez une illustration", illustrations
-                            )
-                            if chosen_image:
-                                chosen_image.seek(0)
-                                path = f"generated_image_{len(selected_image_paths)}.png"
-                                with open(path, "wb") as fh:
-                                    fh.write(chosen_image.getvalue())
-                                selected_image_paths = [path]
-                        continue
-                    if choice == "Joindre":
-                        images = telegram_service.ask_user_images()
-                        start = len(selected_image_paths)
-                        for idx, img in enumerate(images):
-                            img.seek(0)
-                            path = f"user_image_{start + idx}.png"
-                            with open(path, "wb") as fh:
-                                fh.write(img.getvalue())
-                            selected_image_paths.append(path)
-                        continue
-                    if choice == "Retour":
-                        continue
-
-                if action == "Publier":
-                    facebook_service.post_to_facebook_page(
-                        last_post, selected_image_paths or None
-                    )
-                    logger.info("Post généré avec succès.")
-                    final_action = telegram_service.send_message_with_buttons(
-                        "Publication effectuée.", ["Recommencer", "Terminer"]
-                    )
-                    if final_action == "Recommencer":
-                        break
-                    if final_action == "Terminer":
-                        telegram_service.send_message("Fin du processus.")
-                        return
-
-                if action == "Programmer":
-                    now = datetime.utcnow()
-                    target = now.replace(hour=20, minute=0, second=0, microsecond=0)
-                    if now >= target:
-                        target = (now + timedelta(days=1)).replace(
-                            hour=8, minute=0, second=0, microsecond=0
-                        )
-                    facebook_service.schedule_post_to_facebook_page(
-                        last_post, target, selected_image_paths or None
-                    )
-                    logger.info("Publication programmée avec succès.")
-                    final_action = telegram_service.send_message_with_buttons(
-                        "Publication planifiée.", ["Recommencer", "Terminer"]
-                    )
-                    if final_action == "Recommencer":
-                        break
-                    if final_action == "Terminer":
-                        telegram_service.send_message("Fin du processus.")
-                        return
-
-                if action == "Terminer":
-                    telegram_service.send_message("Fin du processus.")
-                    return
-        except Exception as err:  # pragma: no cover - log then continue
-            logger.exception(f"Erreur lors du traitement : {err}")
+    run_workflow(logger, telegram_service, openai_service, facebook_service)
 
 
 if __name__ == "__main__":
     main()
+

--- a/main_workflow.py
+++ b/main_workflow.py
@@ -1,0 +1,60 @@
+"""Point d'entrée principal orchestrant les différents workflows via Telegram."""
+
+from services.openai_service import OpenAIService
+from services.telegram_service import TelegramService
+from services.facebook_service import FacebookService
+from services.odoo_email_service import OdooEmailService
+from config.log_config import setup_logger, log_execution
+
+from audio_post_workflow import run_workflow as run_audio_workflow
+from odoo_email_workflow import run_workflow as run_email_workflow
+
+
+@log_execution
+def main() -> None:
+    logger = setup_logger(__name__)
+
+    openai_service = OpenAIService(logger)
+    telegram_service = TelegramService(logger, openai_service)
+    telegram_service.start()
+
+    while True:
+        action = telegram_service.send_message_with_buttons(
+            "Que souhaitez-vous faire ?",
+            ["Publier sur Facebook", "Mass Mailing", "Quitter"],
+        )
+
+        if action == "Publier sur Facebook":
+            try:
+                facebook_service = FacebookService(logger)
+            except RuntimeError as err:
+                logger.exception(
+                    f"Initialisation du service Facebook échouée : {err}"
+                )
+                telegram_service.send_message(str(err))
+                continue
+            run_audio_workflow(
+                logger, telegram_service, openai_service, facebook_service
+            )
+            continue
+
+        if action == "Mass Mailing":
+            try:
+                email_service = OdooEmailService(logger)
+            except RuntimeError as err:
+                logger.exception(f"Initialisation du service Odoo échouée : {err}")
+                telegram_service.send_message(str(err))
+                continue
+            run_email_workflow(
+                logger, telegram_service, openai_service, email_service
+            )
+            continue
+
+        if action == "Quitter":
+            telegram_service.send_message("Fin du programme.")
+            break
+
+
+if __name__ == "__main__":
+    main()
+

--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -14,12 +14,13 @@ from config import ODOO_MAILING_LIST_IDS
 
 
 @log_execution
-def main() -> None:
-    logger = setup_logger(__name__)
-
-    openai_service = OpenAIService(logger)
-    telegram_service = TelegramService(logger, openai_service)
-    telegram_service.start()
+def run_workflow(
+    logger,
+    telegram_service: "TelegramService",
+    openai_service: "OpenAIService",
+    email_service: "OdooEmailService",
+) -> None:
+    """Exécute le workflow d'email marketing avec des services déjà initialisés."""
 
     tz_name = os.getenv("EMAIL_TIMEZONE", "Europe/Paris")
     try:
@@ -33,6 +34,97 @@ def main() -> None:
         tz = ZoneInfo("UTC")
 
     utc = ZoneInfo("UTC")
+
+    telegram_service.send_message("Prêt pour l'email marketing !")
+
+    text = telegram_service.wait_for_message()
+    if not text:
+        return
+
+    try:
+        subject, html_body = openai_service.generate_marketing_email(text)
+        links: list[tuple[str, str]] = DEFAULT_LINKS.copy()
+        while True:
+            links_preview = email_service.format_links_preview(links)
+            preview_body = html_body
+            if links_preview:
+                preview_body += "\n\n" + links_preview
+            preview_body += "\n\nSe désabonner"
+            preview = f"{subject}\n\n{preview_body}" if subject else preview_body
+            action = telegram_service.send_message_with_buttons(
+                preview,
+                ["Modifier", "Liens", "Programmer", "Terminer"],
+            )
+
+            if action == "Modifier":
+                corrections = telegram_service.ask_text(
+                    "Partagez vos modifications s'il vous plaît !",
+                )
+                html_body = openai_service.apply_corrections(html_body, corrections)
+                continue
+
+            if action == "Liens":
+                link_text = telegram_service.ask_text(
+                    "Fournissez les liens au format 'Nom : URL' séparés par des virgules ou retours à la ligne",
+                )
+                parts = re.split(r",|\n", link_text)
+                new_links = []
+                for part in parts:
+                    if ":" in part:
+                        name, url = part.split(":", 1)
+                        name, url = name.strip(), url.strip()
+                        if name and url:
+                            new_links.append((name, url))
+                existing_urls = {u for _, u in new_links}
+                links = new_links + [l for l in links if l[1] not in existing_urls]
+                continue
+
+            if action == "Programmer":
+                now = datetime.now(tz)
+                days_ahead = (2 - now.weekday()) % 7  # 2 = mercredi
+                target = (now + timedelta(days=days_ahead)).replace(
+                    hour=6, minute=0, second=0, microsecond=0
+                )
+                if target <= now:
+                    target += timedelta(days=7)
+                target_utc = target.astimezone(utc)
+                try:
+                    email_service.schedule_email(
+                        subject,
+                        html_body,
+                        links,
+                        target_utc,
+                        ODOO_MAILING_LIST_IDS,
+                        already_html=True,
+                    )
+                    telegram_service.send_message("Email programmé.")
+                except xmlrpc.client.Fault as err:
+                    logger.exception(f"Erreur lors de la programmation : {err}")
+                    telegram_service.send_message(
+                        f"Erreur lors de la programmation : {err}"
+                    )
+                final_action = telegram_service.send_message_with_buttons(
+                    "Que souhaitez-vous faire ?", ["Recommencer", "Terminer"]
+                )
+                if final_action == "Terminer":
+                    telegram_service.send_message("Fin du workflow email.")
+                    return
+                return
+
+            if action == "Terminer":
+                telegram_service.send_message("Fin du workflow email.")
+                return
+    except Exception as err:  # pragma: no cover - log then continue
+        logger.exception(f"Erreur lors du traitement : {err}")
+
+
+@log_execution
+def main() -> None:
+    logger = setup_logger(__name__)
+
+    openai_service = OpenAIService(logger)
+    telegram_service = TelegramService(logger, openai_service)
+    telegram_service.start()
     try:
         email_service = OdooEmailService(logger)
     except RuntimeError as err:
@@ -40,91 +132,7 @@ def main() -> None:
         telegram_service.send_message(str(err))
         return
 
-    telegram_service.send_message("Prêt pour l'email marketing !")
-
-    while True:
-        text = telegram_service.wait_for_message()
-        if not text:
-            break
-
-        try:
-            subject, html_body = openai_service.generate_marketing_email(text)
-            links: list[tuple[str, str]] = DEFAULT_LINKS.copy()
-            while True:
-                links_preview = email_service.format_links_preview(links)
-                preview_body = html_body
-                if links_preview:
-                    preview_body += "\n\n" + links_preview
-                preview_body += "\n\nSe désabonner"
-                preview = f"{subject}\n\n{preview_body}" if subject else preview_body
-                action = telegram_service.send_message_with_buttons(
-                    preview,
-                    ["Modifier", "Liens", "Programmer", "Terminer"],
-                )
-
-                if action == "Modifier":
-                    corrections = telegram_service.ask_text(
-                        "Partagez vos modifications s'il vous plaît !"
-                    )
-                    html_body = openai_service.apply_corrections(html_body, corrections)
-                    continue
-
-                if action == "Liens":
-                    link_text = telegram_service.ask_text(
-                        "Fournissez les liens au format 'Nom : URL' séparés par des virgules ou retours à la ligne"
-                    )
-                    parts = re.split(r",|\n", link_text)
-                    new_links = []
-                    for part in parts:
-                        if ":" in part:
-                            name, url = part.split(":", 1)
-                            name, url = name.strip(), url.strip()
-                            if name and url:
-                                new_links.append((name, url))
-                    existing_urls = {u for _, u in new_links}
-                    links = new_links + [l for l in links if l[1] not in existing_urls]
-                    continue
-
-                if action == "Programmer":
-                    now = datetime.now(tz)
-                    days_ahead = (2 - now.weekday()) % 7  # 2 = mercredi
-                    target = (now + timedelta(days=days_ahead)).replace(
-                        hour=6, minute=0, second=0, microsecond=0
-                    )
-                    if target <= now:
-                        target += timedelta(days=7)
-                    target_utc = target.astimezone(utc)
-                    try:
-                        email_service.schedule_email(
-                            subject,
-                            html_body,
-                            links,
-                            target_utc,
-                            ODOO_MAILING_LIST_IDS,
-                            already_html=True,
-                        )
-                        telegram_service.send_message("Email programmé.")
-                    except xmlrpc.client.Fault as err:
-                        logger.exception(
-                            f"Erreur lors de la programmation : {err}"
-                        )
-                        telegram_service.send_message(
-                            f"Erreur lors de la programmation : {err}"
-                        )
-                    final_action = telegram_service.send_message_with_buttons(
-                        "Que souhaitez-vous faire ?", ["Recommencer", "Terminer"]
-                    )
-                    if final_action == "Terminer":
-                        telegram_service.send_message("Fin du workflow email.")
-                        return
-                    telegram_service.send_message("Prêt pour l'email marketing !")
-                    break
-
-                if action == "Terminer":
-                    telegram_service.send_message("Fin du workflow email.")
-                    return
-        except Exception as err:  # pragma: no cover - log then continue
-            logger.exception(f"Erreur lors du traitement : {err}")
+    run_workflow(logger, telegram_service, openai_service, email_service)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `main_workflow` entrypoint offering menu to choose Facebook post, mass mailing or quit
- refactor audio and email workflows to accept shared Telegram service and return to main menu on restart/finish

## Testing
- `pytest` *(fails: AssertionError and Odoo service schedule assertions)*
- `pytest tests/test_audio_post_workflow.py tests/test_odoo_email_workflow.py`

------
https://chatgpt.com/codex/tasks/task_e_68a944fe208083258227bf2c3785cd93