### PR TITLE
Ajout d'un bouton Retour aux workflows Telegram

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -22,12 +22,16 @@ def run_workflow(
 ) -> None:
     """Exécute le workflow de publication avec des services déjà initialisés."""
 
-    telegram_service.send_message(
-        "Bienvenue dans le workflow de publication sur Facebook. "
-        "Envoyez le sujet de la publication via un message audio ou un message texte !"
+    action = telegram_service.send_message_with_buttons(
+        "Bienvenue dans le workflow de publication sur Facebook.",
+        ["Continuer", "Retour"],
     )
+    if action == "Retour":
+        return
 
-    text = telegram_service.wait_for_message()
+    text = telegram_service.ask_text(
+        "Envoyez le sujet de la publication via un message audio ou un message texte !",
+    )
     if not text:
         return
 

--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -35,12 +35,16 @@ def run_workflow(
 
     utc = ZoneInfo("UTC")
 
-    telegram_service.send_message(
-        "Bienvenue dans le workflow d'email marketing. "
-        "Envoyez le sujet du mail via un message audio ou un message texte !"
+    action = telegram_service.send_message_with_buttons(
+        "Bienvenue dans le workflow d'email marketing.",
+        ["Continuer", "Retour"],
     )
+    if action == "Retour":
+        return
 
-    text = telegram_service.wait_for_message()
+    text = telegram_service.ask_text(
+        "Envoyez le sujet du mail via un message audio ou un message texte !",
+    )
     if not text:
         return
 

--- a/tests/test_audio_post_workflow.py
+++ b/tests/test_audio_post_workflow.py
@@ -33,7 +33,7 @@ class DummyTelegramService:
     def __init__(self, logger, openai_service):
         self.logger = logger
         self.openai_service = openai_service
-        self.messages = ["transcribed", "/publier", "/terminer"]
+        self.messages = ["/continuer", "transcribed", "/publier", "/terminer"]
         self.index = 0
 
     def start(self):
@@ -64,14 +64,21 @@ class DummyTelegramService:
     def ask_user_images(self):
         return []
 
+    def ask_text(self, prompt):
+        return self.wait_for_message()
+
 
 class EditingDummyTelegramService(DummyTelegramService):
     def __init__(self, logger, openai_service):
         super().__init__(logger, openai_service)
-        self.messages = ["transcribed", "/modifier", "/publier", "/terminer"]
-
-    def ask_text(self, prompt):
-        return "modif"
+        self.messages = [
+            "/continuer",
+            "transcribed",
+            "/modifier",
+            "modif",
+            "/publier",
+            "/terminer",
+        ]
 
 
 class DummyFacebookService:
@@ -101,6 +108,7 @@ class IllustrationDummyTelegramService(DummyTelegramService):
     def __init__(self, logger, openai_service):
         super().__init__(logger, openai_service)
         self.messages = [
+            "/continuer",
             "transcribed",
             "/illustrer",
             "/generer",
@@ -141,7 +149,12 @@ def test_main_flow(monkeypatch):
 class SchedulingDummyTelegramService(DummyTelegramService):
     def __init__(self, logger, openai_service):
         super().__init__(logger, openai_service)
-        self.messages = ["transcribed", "/programmer", "/terminer"]
+        self.messages = [
+            "/continuer",
+            "transcribed",
+            "/programmer",
+            "/terminer",
+        ]
 
 
 def test_scheduling_flow(monkeypatch):
@@ -227,6 +240,7 @@ class AttachDummyTelegramService(DummyTelegramService):
     def __init__(self, logger, openai_service):
         super().__init__(logger, openai_service)
         self.messages = [
+            "/continuer",
             "transcribed",
             "/illustrer",
             "/joindre",

--- a/tests/test_odoo_email_workflow.py
+++ b/tests/test_odoo_email_workflow.py
@@ -27,7 +27,7 @@ class DummyTelegramService:
     def __init__(self, logger, openai_service):
         self.logger = logger
         self.openai_service = openai_service
-        self.messages = ["contenu", "/programmer", "/terminer"]
+        self.messages = ["/continuer", "contenu", "/programmer", "/terminer"]
         self.index = 0
         self.buttons_calls = []
         self.sent_messages = []
@@ -54,7 +54,7 @@ class DummyTelegramService:
         return options[0]
 
     def ask_text(self, prompt):
-        return ""
+        return self.wait_for_message()
 
 
 class DummyOdooEmailService:


### PR DESCRIPTION
## Summary
- permet de revenir au menu principal depuis les workflows Facebook et Mass Mailing
- adapte les tests aux nouvelles étapes de démarrage

## Testing
- `pytest`
- `pytest tests/test_audio_post_workflow.py tests/test_odoo_email_workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_68a94b4a58fc8325b3e23c7344886313