### PR TITLE
Redirect termination to main menu

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -42,7 +42,13 @@ def run_workflow(
         while True:
             action = telegram_service.send_message_with_buttons(
                 last_post,
-                ["Modifier", "Illustrer", "Publier", "Programmer", "Terminer"],
+                [
+                    "Modifier",
+                    "Illustrer",
+                    "Publier",
+                    "Programmer",
+                    "Retour au menu principal",
+                ],
             )
 
             if action == "Modifier":
@@ -108,11 +114,12 @@ def run_workflow(
                 )
                 logger.info("Post généré avec succès.")
                 final_action = telegram_service.send_message_with_buttons(
-                    "Publication effectuée.", ["Recommencer", "Terminer"]
+                    "Publication effectuée.",
+                    ["Recommencer", "Retour au menu principal"],
                 )
                 if final_action == "Recommencer":
                     return
-                telegram_service.send_message("Fin du processus.")
+                telegram_service.send_message("Retour au menu principal.")
                 return
 
             if action == "Programmer":
@@ -127,15 +134,16 @@ def run_workflow(
                 )
                 logger.info("Publication programmée avec succès.")
                 final_action = telegram_service.send_message_with_buttons(
-                    "Publication planifiée.", ["Recommencer", "Terminer"]
+                    "Publication planifiée.",
+                    ["Recommencer", "Retour au menu principal"],
                 )
                 if final_action == "Recommencer":
                     return
-                telegram_service.send_message("Fin du processus.")
+                telegram_service.send_message("Retour au menu principal.")
                 return
 
-            if action == "Terminer":
-                telegram_service.send_message("Fin du processus.")
+            if action == "Retour au menu principal":
+                telegram_service.send_message("Retour au menu principal.")
                 return
     except Exception as err:  # pragma: no cover - log then continue
         logger.exception(f"Erreur lors du traitement : {err}")

--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -60,7 +60,7 @@ def run_workflow(
             preview = f"{subject}\n\n{preview_body}" if subject else preview_body
             action = telegram_service.send_message_with_buttons(
                 preview,
-                ["Modifier", "Liens", "Programmer", "Terminer"],
+                ["Modifier", "Liens", "Programmer", "Retour au menu principal"],
             )
 
             if action == "Modifier":
@@ -111,15 +111,16 @@ def run_workflow(
                         f"Erreur lors de la programmation : {err}"
                     )
                 final_action = telegram_service.send_message_with_buttons(
-                    "Que souhaitez-vous faire ?", ["Recommencer", "Terminer"]
+                    "Que souhaitez-vous faire ?",
+                    ["Recommencer", "Retour au menu principal"],
                 )
-                if final_action == "Terminer":
-                    telegram_service.send_message("Fin du workflow email.")
+                if final_action == "Retour au menu principal":
+                    telegram_service.send_message("Retour au menu principal.")
                     return
                 return
 
-            if action == "Terminer":
-                telegram_service.send_message("Fin du workflow email.")
+            if action == "Retour au menu principal":
+                telegram_service.send_message("Retour au menu principal.")
                 return
     except Exception as err:  # pragma: no cover - log then continue
         logger.exception(f"Erreur lors du traitement : {err}")

--- a/tests/test_audio_post_workflow.py
+++ b/tests/test_audio_post_workflow.py
@@ -33,7 +33,7 @@ class DummyTelegramService:
     def __init__(self, logger, openai_service):
         self.logger = logger
         self.openai_service = openai_service
-        self.messages = ["/continuer", "transcribed", "/publier", "/terminer"]
+        self.messages = ["/continuer", "transcribed", "/publier", "/retour"]
         self.index = 0
 
     def start(self):
@@ -77,7 +77,7 @@ class EditingDummyTelegramService(DummyTelegramService):
             "/modifier",
             "modif",
             "/publier",
-            "/terminer",
+            "/retour",
         ]
 
 
@@ -113,7 +113,7 @@ class IllustrationDummyTelegramService(DummyTelegramService):
             "/illustrer",
             "/generer",
             "/publier",
-            "/terminer",
+            "/retour",
         ]
 
     def ask_options(self, prompt, options):
@@ -153,7 +153,7 @@ class SchedulingDummyTelegramService(DummyTelegramService):
             "/continuer",
             "transcribed",
             "/programmer",
-            "/terminer",
+            "/retour",
         ]
 
 
@@ -245,7 +245,7 @@ class AttachDummyTelegramService(DummyTelegramService):
             "/illustrer",
             "/joindre",
             "/publier",
-            "/terminer",
+            "/retour",
         ]
 
     def ask_user_images(self):

--- a/tests/test_odoo_email_workflow.py
+++ b/tests/test_odoo_email_workflow.py
@@ -27,7 +27,7 @@ class DummyTelegramService:
     def __init__(self, logger, openai_service):
         self.logger = logger
         self.openai_service = openai_service
-        self.messages = ["/continuer", "contenu", "/programmer", "/terminer"]
+        self.messages = ["/continuer", "contenu", "/programmer", "/retour"]
         self.index = 0
         self.buttons_calls = []
         self.sent_messages = []
@@ -87,5 +87,5 @@ def test_final_options(monkeypatch):
     workflow_main()
 
     tg = DummyTelegramService.instance
-    assert ["Recommencer", "Terminer"] in tg.buttons_calls
-    assert "Fin du workflow email." in tg.sent_messages
+    assert ["Recommencer", "Retour au menu principal"] in tg.buttons_calls
+    assert "Retour au menu principal." in tg.sent_messages


### PR DESCRIPTION
## Summary
- Replace termination options with "Retour au menu principal" in audio and email workflows
- Update tests to reflect returning to main menu

## Testing
- `pytest`
- `pytest tests/test_audio_post_workflow.py tests/test_odoo_email_workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_68a94e45e5a48325b5db3a57bb3c9191