### PR TITLE
Handle TimeoutError during initial workflow prompts

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -23,11 +23,17 @@ def run_workflow(
     """Exécute le workflow de publication avec des services déjà initialisés."""
     timeout = 300
 
-    action = telegram_service.send_message_with_buttons(
-        "Bienvenue dans le workflow de publication sur Facebook.",
-        ["Continuer", "Retour"],
-        timeout=timeout,
-    )
+    try:
+        action = telegram_service.send_message_with_buttons(
+            "Bienvenue dans le workflow de publication sur Facebook.",
+            ["Continuer", "Retour"],
+            timeout=timeout,
+        )
+    except TimeoutError:
+        telegram_service.send_message(
+            "Inactivité prolongée, retour au menu principal."
+        )
+        return
     if action == "Retour":
         return
 

--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -36,15 +36,15 @@ def run_workflow(
     utc = ZoneInfo("UTC")
     timeout = 300
 
-    action = telegram_service.send_message_with_buttons(
-        "Bienvenue dans le workflow d'email marketing.",
-        ["Continuer", "Retour"],
-        timeout=timeout,
-    )
-    if action == "Retour":
-        return
-
     try:
+        action = telegram_service.send_message_with_buttons(
+            "Bienvenue dans le workflow d'email marketing.",
+            ["Continuer", "Retour"],
+            timeout=timeout,
+        )
+        if action == "Retour":
+            return
+
         text = telegram_service.ask_text(
             "Envoyez le sujet du mail via un message audio ou un message texte !",
             timeout=timeout,


### PR DESCRIPTION
## Summary
- Guard initial Telegram prompts against inactivity in email and audio workflows
- Notify users and return to main menu on TimeoutError

## Testing
- `pytest -q` *(fails: execute_kw call not found; Esplas-de-Sérou assertion; 'Fête du village' assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68a955880b6883258349c7952ebb664e