### PR TITLE
Ensure single Telegram workflow and restore webhook after exit

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -39,6 +39,8 @@ ODOO_EMAIL_FROM = os.getenv("ODOO_EMAIL_FROM", "")
 # Used by ``telegram_service`` to send notifications to a specific user.
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_USER_ID = int(os.getenv("TELEGRAM_USER_ID", "0"))
+# URL du webhook Telegram pour réactiver les notifications après l'arrêt du bot
+TELEGRAM_WEBHOOK_URL = os.getenv("TELEGRAM_WEBHOOK_URL", "")
 
 # --- Facebook configuration ---------------------------------------------------
 # Required by the Facebook posting utilities to publish on a page.

--- a/generate_post/prompt_builder.py
+++ b/generate_post/prompt_builder.py
@@ -8,6 +8,7 @@ from typing import Dict
 TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "prompts", "event_template.txt")
 
 _FIELDS = {
+    "objet": "",
     "date": "",
     "horaires": "",
     "lieu": "",

--- a/generate_post/prompts/event_template.txt
+++ b/generate_post/prompts/event_template.txt
@@ -1,5 +1,6 @@
 Rédige un post pour les réseaux sociaux à partir des informations ci-dessous.
 
+- Objet : {objet}
 - Date : {date}
 - Horaires : {horaires}
 - Lieu : {lieu}

--- a/main_workflow.py
+++ b/main_workflow.py
@@ -54,6 +54,8 @@ def main() -> None:
             telegram_service.send_message("Fin du programme.")
             break
 
+    telegram_service.stop()
+
 
 if __name__ == "__main__":
     main()

--- a/services/odoo_email_service.py
+++ b/services/odoo_email_service.py
@@ -162,7 +162,7 @@ class OdooEmailService:
 
         if list_ids is None:
             list_ids = ODOO_MAILING_LIST_IDS
-        links = self._normalize_links(list(links))
+        links = self._normalize_links(list(links) + DEFAULT_LINKS)
 
         is_html = already_html or bool(re.search(r"<[^>]+>", body))
         if is_html:

--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -151,7 +151,7 @@ class OpenAIService:
         prompt = (
             f"Crée une illustration dans un style {style} représentant la "
             f"publication suivante : {post}. L'image doit contenir uniquement le "
-            f"texte Esplas-de-Sérou et ne contenir aucun autre texte."
+            f"texte Esplas-de-Sérou {date_str} et ne contenir aucun autre texte."
         )
 
         try:

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1,0 +1,29 @@
+import threading
+from unittest.mock import patch
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # type: ignore
+
+import webhook_server
+
+
+def test_webhook_allows_new_run_after_previous_completed():
+    client = TestClient(webhook_server.app)
+
+    with patch("main_workflow.main"):
+        # First trigger
+        response = client.post("/webhook", json={})
+        assert response.json() == {"ok": True}
+        t1 = webhook_server._workflow_thread
+        assert isinstance(t1, threading.Thread)
+        t1.join()
+        assert webhook_server._workflow_thread is None
+
+        # Second trigger after previous completion
+        response = client.post("/webhook", json={})
+        assert response.json() == {"ok": True}
+        t2 = webhook_server._workflow_thread
+        assert isinstance(t2, threading.Thread)
+        t2.join()


### PR DESCRIPTION
## Summary
- Add `TelegramService.stop()` to terminate polling and restore the webhook
- Guard webhook server with thread tracking to prevent parallel workflows
- Include event date in illustration prompts and default links in marketing emails
- Extend prompt builder template with an `objet` field
- Add tests for stopping Telegram service and restarting workflow via webhook

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a980b2b9ac8325af6a4bd91a56840a