### PR TITLE
Restore Telegram webhook on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ ODOO_USER=<utilisateur>
 ODOO_PASSWORD=<mot de passe>
 TELEGRAM_BOT_TOKEN=<token du bot Telegram>
 TELEGRAM_USER_ID=<identifiant Telegram du destinataire>
+TELEGRAM_WEBHOOK_URL=<URL du webhook Telegram>
 FACEBOOK_PAGE_ID=<id de votre page Facebook>
 PAGE_ACCESS_TOKEN=<token de la page Facebook>
 ```
 
-Ces variables permettent de se connecter à Odoo, à l'API OpenAI, à Facebook et à Telegram pour l'envoi de notifications. `TELEGRAM_BOT_TOKEN` et `TELEGRAM_USER_ID` sont utilisés par `services/telegram_service.py` pour envoyer des messages, tandis que `FACEBOOK_PAGE_ID` et `PAGE_ACCESS_TOKEN` servent aux modules de publication Facebook.
+Ces variables permettent de se connecter à Odoo, à l'API OpenAI, à Facebook et à Telegram pour l'envoi de notifications. `TELEGRAM_BOT_TOKEN`, `TELEGRAM_USER_ID` et `TELEGRAM_WEBHOOK_URL` sont utilisés par `services/telegram_service.py` pour envoyer des messages et réactiver le webhook, tandis que `FACEBOOK_PAGE_ID` et `PAGE_ACCESS_TOKEN` servent aux modules de publication Facebook.
 
 ## Services principaux
 

--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -176,13 +176,22 @@ def main() -> None:
     telegram_service = TelegramService(logger, openai_service)
     telegram_service.start()
     try:
-        facebook_service = FacebookService(logger)
-    except RuntimeError as err:
-        logger.exception(f"Initialisation du service Facebook échouée : {err}")
-        telegram_service.send_message(str(err))
-        return
+        try:
+            facebook_service = FacebookService(logger)
+        except RuntimeError as err:
+            logger.exception(
+                f"Initialisation du service Facebook échouée : {err}"
+            )
+            telegram_service.send_message(str(err))
+            return
 
-    run_workflow(logger, telegram_service, openai_service, facebook_service)
+        run_workflow(
+            logger, telegram_service, openai_service, facebook_service
+        )
+    except KeyboardInterrupt:
+        logger.info("Arrêt manuel du programme")
+    finally:
+        telegram_service.stop()
 
 
 if __name__ == "__main__":

--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -146,13 +146,22 @@ def main() -> None:
     telegram_service = TelegramService(logger, openai_service)
     telegram_service.start()
     try:
-        email_service = OdooEmailService(logger)
-    except RuntimeError as err:
-        logger.exception(f"Initialisation du service Odoo échouée : {err}")
-        telegram_service.send_message(str(err))
-        return
+        try:
+            email_service = OdooEmailService(logger)
+        except RuntimeError as err:
+            logger.exception(
+                f"Initialisation du service Odoo échouée : {err}"
+            )
+            telegram_service.send_message(str(err))
+            return
 
-    run_workflow(logger, telegram_service, openai_service, email_service)
+        run_workflow(
+            logger, telegram_service, openai_service, email_service
+        )
+    except KeyboardInterrupt:
+        logger.info("Arrêt manuel du programme")
+    finally:
+        telegram_service.stop()
 
 
 if __name__ == "__main__":

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Request
 import threading
 import main_workflow
+import time
 
 app = FastAPI()
 
@@ -14,6 +15,8 @@ def _run_workflow() -> None:
     try:
         main_workflow.main()
     finally:
+        # Delay cleanup slightly so the thread reference remains accessible
+        time.sleep(0.1)
         with _lock:
             _workflow_thread = None
 


### PR DESCRIPTION
## Summary
- ensure `TelegramService` always resets the webhook on manual interruption
- document `TELEGRAM_WEBHOOK_URL` env variable
- keep webhook server thread reference until cleanup completes

## Testing
- `pytest tests/test_telegram_service.py tests/test_webhook_server.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a98a8915d48325ab24386fbbe66b40