### PR TITLE
Add return option when prompting for post or email subject

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -44,11 +44,12 @@ def run_workflow(
         return
 
     try:
-        text = telegram_service.ask_text(
+        text = telegram_service.ask_text_or_return(
             "Envoyez le sujet de la publication via un message audio ou un message texte !",
             timeout=timeout,
         )
         if not text:
+            telegram_service.send_message("Retour au menu principal.")
             return
 
         last_post = openai_service.generate_event_post(text)

--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -53,11 +53,12 @@ def run_workflow(
         if action == "Retour":
             return
 
-        text = telegram_service.ask_text(
+        text = telegram_service.ask_text_or_return(
             "Envoyez le sujet du mail via un message audio ou un message texte !",
             timeout=timeout,
         )
         if not text:
+            telegram_service.send_message("Retour au menu principal.")
             return
 
         subject, html_body = openai_service.generate_marketing_email(text)

--- a/tests/test_audio_post_workflow.py
+++ b/tests/test_audio_post_workflow.py
@@ -39,6 +39,9 @@ class DummyTelegramService:
     def start(self):
         pass
 
+    def stop(self):
+        pass
+
     def send_message(self, msg):
         pass
 
@@ -66,6 +69,13 @@ class DummyTelegramService:
 
     def ask_text(self, prompt, timeout=None):
         return self.wait_for_message()
+
+    def ask_text_or_return(self, prompt, timeout=None):
+        msg = self.wait_for_message()
+        cmd = msg.lstrip("/").lower()
+        if cmd.startswith("retour"):
+            return None
+        return msg
 
 
 class EditingDummyTelegramService(DummyTelegramService):

--- a/tests/test_odoo_email_workflow.py
+++ b/tests/test_odoo_email_workflow.py
@@ -39,6 +39,9 @@ class DummyTelegramService:
     def send_message(self, msg):
         self.sent_messages.append(msg)
 
+    def stop(self):
+        pass
+
     def wait_for_message(self):
         msg = self.messages[self.index]
         self.index += 1
@@ -55,6 +58,13 @@ class DummyTelegramService:
 
     def ask_text(self, prompt, timeout=None):
         return self.wait_for_message()
+
+    def ask_text_or_return(self, prompt, timeout=None):
+        msg = self.wait_for_message()
+        cmd = msg.lstrip("/").lower()
+        if cmd.startswith("retour"):
+            return None
+        return msg
 
 
 class DummyOdooEmailService:


### PR DESCRIPTION
## Summary
- allow returning to main menu when prompting for email or post subject
- add `ask_text_or_return` helper to TelegramService

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9a087700c83258420f1f979c9b719