### PR TITLE
feat: redact sensitive data in logs

### DIFF
--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -1,12 +1,18 @@
 # tests/test_log_config.py
 
+import logging
+import os
 import unittest
+import io
 from config.log_config import setup_logger
 
 
 class TestLogger(unittest.TestCase):
     def setUp(self):
-        # Initialisation du logger avant chaque test
+        # Préparation des variables sensibles et du logger
+        os.environ["TELEGRAM_BOT_TOKEN"] = "super-secret-token"
+        root_logger = logging.getLogger()
+        root_logger.filters = []
         self.logger = setup_logger(__name__)
 
     def test_info_log(self):
@@ -23,6 +29,20 @@ class TestLogger(unittest.TestCase):
             self.assertTrue(True)
         except Exception as e:
             self.fail(f"Erreur inattendue lors de l'écriture d'un log ERROR : {e}")
+
+    def test_sensitive_data_redacted(self):
+        secret = os.environ["TELEGRAM_BOT_TOKEN"]
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        root_logger = logging.getLogger()
+        root_logger.addHandler(handler)
+        try:
+            self.logger.info("Token: %s", secret)
+        finally:
+            root_logger.removeHandler(handler)
+        log_output = stream.getvalue()
+        self.assertNotIn(secret, log_output)
+        self.assertIn("[REDACTED]", log_output)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add SensitiveDataFilter to mask tokens and API keys from log output
- cover logging redaction with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9a1d30c7c8325ad4873ed348734af