### PR TITLE
feat: improve illustration workflow with text and regeneration options

### DIFF
--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -4,7 +4,6 @@ import re
 from io import BytesIO
 from pathlib import Path
 from typing import List
-from datetime import datetime
 
 from openai import OpenAI, OpenAIError
 from config.log_config import log_execution
@@ -135,23 +134,32 @@ class OpenAIService:
 
     @log_execution
     def generate_illustrations(
-        self, post: str, style: str, event_date: str | None = None
+        self,
+        post: str,
+        style: str,
+        text: str | None = None,
+        event_date: str | None = None,
     ) -> List[BytesIO]:
         """Génère une liste d'illustrations en mémoire dans un style donné.
 
-        L'illustration doit mettre en scène la publication tout en affichant
-        uniquement le texte ``Esplas-de-Sérou <date>`` où ``<date>`` est la date
-        fournie ou, à défaut, la date courante.
+        L'illustration doit mettre en scène la publication tout en affichant le
+        texte ``Esplas-de-Sérou`` complété éventuellement par ``<date>`` et
+        ``<texte>`` lorsque fournis.
 
         Les images renvoyées par l'API sont décodées depuis du base64 et
         converties en ``BytesIO`` afin d'éviter toute écriture sur disque.
         """
 
-        date_str = event_date or datetime.utcnow().strftime("%d/%m/%Y")
+        parts = ["Esplas-de-Sérou"]
+        if event_date:
+            parts.append(event_date)
+        if text:
+            parts.append(text)
+        text_prompt = " ".join(parts)
         prompt = (
             f"Crée une illustration dans un style {style} représentant la "
             f"publication suivante : {post}. L'image doit contenir uniquement le "
-            f"texte Esplas-de-Sérou {date_str} et ne contenir aucun autre texte."
+            f"texte {text_prompt} et ne contenir aucun autre texte."
         )
 
         try:

--- a/tests/test_audio_post_workflow.py
+++ b/tests/test_audio_post_workflow.py
@@ -21,7 +21,7 @@ class DummyOpenAIService:
         assert text == "transcribed"
         return "post"
 
-    def generate_illustrations(self, prompt, style):
+    def generate_illustrations(self, prompt, style, text=None, event_date=None):
         return []
 
     def apply_corrections(self, text, corrections):
@@ -109,8 +109,8 @@ class IllustrationDummyOpenAIService(DummyOpenAIService):
         super().__init__(logger)
         self.called_with = None
 
-    def generate_illustrations(self, prompt, style):
-        self.called_with = (prompt, style)
+    def generate_illustrations(self, prompt, style, text=None, event_date=None):
+        self.called_with = (prompt, style, text, event_date)
         return [BytesIO(b"img")]
 
 
@@ -122,6 +122,7 @@ class IllustrationDummyTelegramService(DummyTelegramService):
             "transcribed",
             "/illustrer",
             "/generer",
+            "/valider",
             "/publier",
             "/retour",
         ]
@@ -242,7 +243,7 @@ def test_illustration_flow(monkeypatch, tmp_path):
 
     workflow_main()
 
-    assert openai_service.called_with == ("post", "Réaliste")
+    assert openai_service.called_with == ("post", "Réaliste", None, None)
     assert fb_service.posted == ("post", ["generated_image_0.png"])
 
 

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -107,12 +107,12 @@ def test_generate_illustrations_returns_bytesio(mock_openai):
 
     service = OpenAIService(MagicMock())
     images = service.generate_illustrations(
-        "prompt", "Cubisme", event_date="01/02/2025"
+        "prompt", "Cubisme", text="Texte", event_date="01/02/2025"
     )
     assert len(images) == 2
     assert all(isinstance(img, BytesIO) for img in images)
     _, kwargs = mock_client.images.generate.call_args
-    assert "Esplas-de-Sérou 01/02/2025" in kwargs["prompt"]
+    assert "Esplas-de-Sérou 01/02/2025 Texte" in kwargs["prompt"]
     assert "Cubisme" in kwargs["prompt"]
 
 


### PR DESCRIPTION
## Summary
- allow choosing text and date when generating illustrations
- enable regenerating images or returning to publication step
- support new illustration parameters in OpenAI service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9f7a55f308325b22958addb667b1d