### PR TITLE
Fix Facebook post scheduling timezone handling

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -5,7 +5,7 @@ un post à partir du contenu obtenu. Les interactions utilisateurs sont
 désormais réalisées via un véritable bot Telegram.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from services.facebook_service import FacebookService
 from services.openai_service import OpenAIService
@@ -170,7 +170,7 @@ def run_workflow(
                 return
 
             if action == "Programmer":
-                now = datetime.utcnow()
+                now = datetime.now(timezone.utc)
                 target = now.replace(hour=20, minute=0, second=0, microsecond=0)
                 if now >= target:
                     target = (now + timedelta(days=1)).replace(

--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 from io import BytesIO
-from datetime import datetime
+from datetime import datetime, timezone
 
 import config
 import requests
@@ -87,6 +87,10 @@ class FacebookService:
     ) -> dict | None:
         """Planifie la publication d'un post sur la page principale."""
         files, fh = self._prepare_files(image)
+        if publish_time.tzinfo is None:
+            publish_time = publish_time.replace(tzinfo=timezone.utc)
+        else:
+            publish_time = publish_time.astimezone(timezone.utc)
         timestamp = int(publish_time.timestamp())
 
         if files:

--- a/tests/test_audio_post_workflow.py
+++ b/tests/test_audio_post_workflow.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BytesIO
 import audio_post_workflow
 from audio_post_workflow import main as workflow_main
@@ -191,6 +191,7 @@ def test_scheduling_flow(monkeypatch):
     assert fb_service.posted is None
     assert fb_service.scheduled[0] == "post"
     assert isinstance(fb_service.scheduled[1], datetime)
+    assert fb_service.scheduled[1].tzinfo is timezone.utc
 
 
 def test_modification_flow(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure scheduled Facebook posts use UTC-aware timestamps
- handle naive datetimes in FacebookService by converting to UTC
- verify scheduling workflow and timestamp conversion with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa07dfc7bc8325b4a35450a9b7b11b