### PR TITLE
Handle local timezone for scheduled Facebook posts

### DIFF
--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -88,9 +88,13 @@ class FacebookService:
         """Planifie la publication d'un post sur la page principale."""
         files, fh = self._prepare_files(image)
         if publish_time.tzinfo is None:
-            publish_time = publish_time.replace(tzinfo=timezone.utc)
-        else:
-            publish_time = publish_time.astimezone(timezone.utc)
+            # Sans fuseau, interpréter la date comme locale. En supposant UTC,
+            # un post programmé risquait d'être planifié dans le passé et
+            # donc publié immédiatement.
+            publish_time = publish_time.replace(
+                tzinfo=datetime.now().astimezone().tzinfo
+            )
+        publish_time = publish_time.astimezone(timezone.utc)
         timestamp = int(publish_time.timestamp())
 
         if files:

--- a/tests/test_facebook_service.py
+++ b/tests/test_facebook_service.py
@@ -5,7 +5,7 @@ import logging
 import unittest
 from io import BytesIO
 import importlib
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 
 def _server_proxy(url):
@@ -159,4 +159,34 @@ def test_schedule_post_uses_utc_timestamp(mock_post):
 
     kwargs = mock_post.call_args.kwargs
     expected_ts = int(datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).timestamp())
+    assert kwargs["data"]["scheduled_publish_time"] == expected_ts
+
+
+@patch.object(config, "FACEBOOK_PAGE_ID", "123")
+@patch.object(config, "PAGE_ACCESS_TOKEN", "token")
+@patch("services.facebook_service.requests.post")
+@patch("services.facebook_service.datetime")
+def test_schedule_post_naive_time_uses_local_timezone(
+    mock_datetime, mock_post
+):
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.text = "ok"
+    mock_post.return_value = mock_response
+
+    local_tz = timezone(timedelta(hours=2))
+    mock_now = Mock()
+    mock_now.astimezone.return_value = datetime(2023, 1, 1, tzinfo=local_tz)
+    mock_datetime.now.return_value = mock_now
+
+    service = FacebookService(logger=logging.getLogger("test"))
+    publish_time = datetime(2024, 1, 1, 12, 0)
+    service.schedule_post_to_facebook_page("hello", publish_time)
+
+    kwargs = mock_post.call_args.kwargs
+    expected_ts = int(
+        datetime(2024, 1, 1, 12, 0, tzinfo=local_tz)
+        .astimezone(timezone.utc)
+        .timestamp()
+    )
     assert kwargs["data"]["scheduled_publish_time"] == expected_ts


### PR DESCRIPTION
## Summary
- Interpret naive publish_time as local timezone before converting to UTC to avoid immediate publication
- Add regression test ensuring scheduled posts respect local timezone

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa246746f88325a112a984a7e42ce7