### PR TITLE
Fix scheduling for Facebook posts with photos

### DIFF
--- a/services/facebook_service.py
+++ b/services/facebook_service.py
@@ -1,6 +1,7 @@
 from typing import List, Union
 from io import BytesIO
 from datetime import datetime, timezone
+import json
 
 import config
 import requests
@@ -97,14 +98,48 @@ class FacebookService:
         publish_time = publish_time.astimezone(timezone.utc)
         timestamp = int(publish_time.timestamp())
 
+        media_id = None
         if files:
-            url = f"https://graph.facebook.com/{self.page_id}/photos"
+            upload_url = f"https://graph.facebook.com/{self.page_id}/photos"
+            upload_data = {
+                "published": "false",
+                "access_token": self.page_token,
+            }
+            try:
+                upload_resp = requests.post(
+                    upload_url, data=upload_data, files=files, timeout=10
+                )
+                upload_resp.raise_for_status()
+                self.logger.info(
+                    f"Facebook page response: {upload_resp.text}"
+                )
+                media_id = upload_resp.json().get("id")
+            except Exception as e:
+                response = getattr(e, "response", None)
+                if response is not None:
+                    try:
+                        error_detail = response.json()
+                    except ValueError:
+                        error_detail = response.text
+                else:
+                    error_detail = str(e)
+                self.logger.exception(
+                    f"Erreur lors du téléversement de la photo : {error_detail}"
+                )
+                raise requests.HTTPError(response=response) from e
+            finally:
+                if fh:
+                    fh.close()
+
+            url = f"https://graph.facebook.com/{self.page_id}/feed"
             data = {
-                "caption": message,
+                "message": message,
                 "published": "false",
                 "scheduled_publish_time": timestamp,
                 "access_token": self.page_token,
+                "attached_media[0]": json.dumps({"media_fbid": media_id}),
             }
+            request_kwargs = {"data": data, "timeout": 10}
         else:
             url = f"https://graph.facebook.com/{self.page_id}/feed"
             data = {
@@ -113,10 +148,7 @@ class FacebookService:
                 "scheduled_publish_time": timestamp,
                 "access_token": self.page_token,
             }
-
-        request_kwargs = {"data": data, "timeout": 10}
-        if files:
-            request_kwargs["files"] = files
+            request_kwargs = {"data": data, "timeout": 10}
 
         try:
             response = requests.post(url, **request_kwargs)
@@ -136,7 +168,4 @@ class FacebookService:
                 f"Erreur lors de la programmation sur la page Facebook : {error_detail}"
             )
             raise requests.HTTPError(response=response) from e
-        finally:
-            if fh:
-                fh.close()
 

--- a/tests/test_facebook_service.py
+++ b/tests/test_facebook_service.py
@@ -6,6 +6,7 @@ import unittest
 from io import BytesIO
 import importlib
 from datetime import datetime, timezone, timedelta
+import json
 
 
 def _server_proxy(url):
@@ -190,3 +191,38 @@ def test_schedule_post_naive_time_uses_local_timezone(
         .timestamp()
     )
     assert kwargs["data"]["scheduled_publish_time"] == expected_ts
+
+
+@patch.object(config, "FACEBOOK_PAGE_ID", "123")
+@patch.object(config, "PAGE_ACCESS_TOKEN", "token")
+@patch("builtins.open", new_callable=mock_open)
+@patch("services.facebook_service.requests.post")
+def test_schedule_post_with_image_uses_feed(mock_post, mock_file):
+    upload_response = Mock()
+    upload_response.raise_for_status = Mock()
+    upload_response.text = "upload"
+    upload_response.json.return_value = {"id": "42"}
+
+    schedule_response = Mock()
+    schedule_response.raise_for_status = Mock()
+    schedule_response.text = "scheduled"
+
+    mock_post.side_effect = [upload_response, schedule_response]
+
+    service = FacebookService(logger=logging.getLogger("test"))
+    publish_time = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    service.schedule_post_to_facebook_page("hello", publish_time, "img.jpg")
+
+    assert mock_post.call_count == 2
+
+    upload_call, schedule_call = mock_post.call_args_list
+
+    assert upload_call.args[0] == "https://graph.facebook.com/123/photos"
+    assert "files" in upload_call.kwargs
+
+    assert schedule_call.args[0] == "https://graph.facebook.com/123/feed"
+    data = schedule_call.kwargs["data"]
+    expected_ts = int(publish_time.timestamp())
+    assert data["scheduled_publish_time"] == expected_ts
+    assert json.loads(data["attached_media[0]"]) == {"media_fbid": "42"}
+    mock_file.return_value.close.assert_called_once()


### PR DESCRIPTION
## Summary
- Upload images before scheduling and reference them in scheduled Facebook posts
- Test that scheduling with an image performs upload and uses the feed endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa2f7090ac8325bb83e7e33734818e