### PR TITLE
Quit program after 10min inactivity

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -21,7 +21,7 @@ def run_workflow(
     facebook_service: "FacebookService",
 ) -> None:
     """Exécute le workflow de publication avec des services déjà initialisés."""
-    timeout = 300
+    timeout = 600
 
     try:
         action = telegram_service.send_message_with_buttons(
@@ -38,8 +38,10 @@ def run_workflow(
             timeout=timeout,
         )
     except TimeoutError:
-        telegram_service.send_message("Inactivité prolongée, retour au menu principal.")
-        return
+        telegram_service.send_message(
+            "Inactivité prolongée, fermeture du programme."
+        )
+        raise SystemExit
     if action == "Retour":
         return
 
@@ -194,8 +196,10 @@ def run_workflow(
                 telegram_service.send_message("Retour au menu principal.")
                 return
     except TimeoutError:
-        telegram_service.send_message("Inactivité prolongée, retour au menu principal.")
-        return
+        telegram_service.send_message(
+            "Inactivité prolongée, fermeture du programme."
+        )
+        raise SystemExit
     except Exception as err:  # pragma: no cover - log then continue
         logger.exception(f"Erreur lors du traitement : {err}")
 

--- a/main_workflow.py
+++ b/main_workflow.py
@@ -17,13 +17,21 @@ def main() -> None:
     openai_service = OpenAIService(logger)
     telegram_service = TelegramService(logger, openai_service)
     telegram_service.start()
+    timeout = 600
 
     try:
         while True:
-            action = telegram_service.send_message_with_buttons(
-                "Que souhaitez-vous faire ?",
-                ["Publier sur Facebook", "Mass Mailing", "Quitter"],
-            )
+            try:
+                action = telegram_service.send_message_with_buttons(
+                    "Que souhaitez-vous faire ?",
+                    ["Publier sur Facebook", "Mass Mailing", "Quitter"],
+                    timeout=timeout,
+                )
+            except TimeoutError:
+                telegram_service.send_message(
+                    "Inactivité prolongée, fermeture du programme."
+                )
+                break
 
             if action == "Publier sur Facebook":
                 try:

--- a/odoo_email_workflow.py
+++ b/odoo_email_workflow.py
@@ -34,7 +34,7 @@ def run_workflow(
         tz = ZoneInfo("UTC")
 
     utc = ZoneInfo("UTC")
-    timeout = 300
+    timeout = 600
 
     try:
         action = telegram_service.send_message_with_buttons(
@@ -139,8 +139,10 @@ def run_workflow(
                 telegram_service.send_message("Retour au menu principal.")
                 return
     except TimeoutError:
-        telegram_service.send_message("Inactivité prolongée, retour au menu principal.")
-        return
+        telegram_service.send_message(
+            "Inactivité prolongée, fermeture du programme."
+        )
+        raise SystemExit
     except Exception as err:  # pragma: no cover - log then continue
         logger.exception(f"Erreur lors du traitement : {err}")
 


### PR DESCRIPTION
## Summary
- exit audio and email workflows after 10 minutes of inactivity
- close the bot if the main menu is idle for 10 minutes

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68aa99113bc88325a66eea3da57ff202