### PR TITLE
Use local timezone for scheduled Facebook posts

### DIFF
--- a/audio_post_workflow.py
+++ b/audio_post_workflow.py
@@ -5,7 +5,8 @@ un post à partir du contenu obtenu. Les interactions utilisateurs sont
 désormais réalisées via un véritable bot Telegram.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from services.facebook_service import FacebookService
 from services.openai_service import OpenAIService
@@ -172,7 +173,8 @@ def run_workflow(
                 return
 
             if action == "Programmer":
-                now = datetime.now(timezone.utc)
+                local_tz = ZoneInfo("Europe/Paris")
+                now = datetime.now(local_tz)
                 target = now.replace(hour=20, minute=0, second=0, microsecond=0)
                 if now >= target:
                     target = (now + timedelta(days=1)).replace(

--- a/tests/test_audio_post_workflow.py
+++ b/tests/test_audio_post_workflow.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from io import BytesIO
 import audio_post_workflow
 from audio_post_workflow import main as workflow_main
@@ -191,7 +192,7 @@ def test_scheduling_flow(monkeypatch):
     assert fb_service.posted is None
     assert fb_service.scheduled[0] == "post"
     assert isinstance(fb_service.scheduled[1], datetime)
-    assert fb_service.scheduled[1].tzinfo is timezone.utc
+    assert fb_service.scheduled[1].tzinfo == ZoneInfo("Europe/Paris")
 
 
 def test_modification_flow(monkeypatch):


### PR DESCRIPTION
## Summary
- Schedule Facebook posts using the Europe/Paris timezone instead of UTC
- Update scheduling test to expect Europe/Paris timezone-aware datetimes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac213b395483259f6f670e25ad5555